### PR TITLE
Allow partial decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.33.0] – 2022-04-01
+
+### New 
+
+- `allow_partial` flag in all `abi.decode_*` functions. This flag controls decoder behaviour whether return error or not in case of incomplete BOC decoding
+
 ## [1.32.0] – 2022-03-22
 
 ### New 

--- a/ton_client/src/abi/decode_data.rs
+++ b/ton_client/src/abi/decode_data.rs
@@ -15,6 +15,13 @@ pub struct ParamsOfDecodeAccountData {
 
     /// Data BOC or BOC handle
     pub data: String,
+
+    /// Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC.
+    /// Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC:
+    /// `true` - return decoded values
+    /// `false` - return error of incomplete BOC deserialization (default)
+    #[serde(default)]
+    pub allow_partial: bool,
 }
 
 #[derive(Serialize, Deserialize, ApiType, Default)]
@@ -34,7 +41,7 @@ pub async fn decode_account_data(
     let (_, data) = deserialize_cell_from_boc(&context, &params.data, "contract data").await?;
     let abi = params.abi.abi()?;
 
-    let tokens = abi.decode_storage_fields(data.into())
+    let tokens = abi.decode_storage_fields(data.into(), params.allow_partial)
         .map_err(|e| Error::invalid_data_for_decode(e))?;
 
     let data = Detokenizer::detokenize_to_json_value(&tokens)

--- a/ton_client/src/abi/init_data.rs
+++ b/ton_client/src/abi/init_data.rs
@@ -124,6 +124,12 @@ pub struct ParamsOfDecodeInitialData  {
     pub abi: Option<Abi>,
     /// Data BOC or BOC handle
     pub data: String,
+    /// Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC.
+    /// Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC:
+    /// `true` - return decoded values
+    /// `false` - return error of incomplete BOC deserialization (default)
+    #[serde(default)]
+    pub allow_partial: bool,
 }
 
 #[derive(Serialize, Deserialize, ApiType, Default)]
@@ -152,7 +158,7 @@ pub async fn decode_initial_data(
     let initial_data = if let Some(abi) = params.abi {
         let abi = abi.abi()?;
 
-        let tokens = abi.decode_data(data)
+        let tokens = abi.decode_data(data, params.allow_partial)
             .map_err(|e| Error::invalid_data_for_decode(e))?;
 
         let initial_data = ton_abi::token::Detokenizer::detokenize_to_json_value(&tokens)

--- a/ton_client/src/abi/tests.rs
+++ b/ton_client/src/abi/tests.rs
@@ -301,6 +301,7 @@ fn decode_v2() {
                 ParamsOfDecodeMessage {
                     abi: events_abi.clone(),
                     message: message.into(),
+                    allow_partial: false,
                 },
             )
             .unwrap();
@@ -320,6 +321,7 @@ fn decode_v2() {
                     abi: events_abi.clone(),
                     body,
                     is_internal: parsed.parsed["msg_type_name"] == "Internal",
+                    allow_partial: false,
                 },
             )
             .unwrap();
@@ -354,6 +356,7 @@ fn decode_v2() {
         abi: events_abi.clone(),
         body: "te6ccgEBAgEAlgAB4a3f2/jCeWWvgMoAXOakv3VSD56sQrDPT76n1cbrSvpZ0BCs0KEUy2Duvo3zPExePONW3TYy0MCA1i+FFRXcSIXTHxAj/Hd67jWQF7peccWoU/dbMCBJBB6YdPCVZcJlJkAAAF0ZyXLg19VzGQVviwSgAQBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=".into(),
         is_internal: false,
+        allow_partial: false,
     }).unwrap();
     let expected = DecodedMessageBody {
         body_type: MessageBodyType::Input,
@@ -914,7 +917,7 @@ fn test_decode_account_data() {
     let client = TestClient::new();
     let decoded = client.request::<_, ResultOfDecodeAccountData>(
         "abi.decode_account_data",
-        ParamsOfDecodeAccountData { data, abi },
+        ParamsOfDecodeAccountData { data, abi, allow_partial: false, },
     )
     .unwrap()
     .data;
@@ -962,6 +965,7 @@ fn test_init_data() {
             ParamsOfDecodeInitialData {
                 abi: Some(abi.clone()),
                 data: data.clone(),
+                allow_partial: false,
             },
         )
         .unwrap();
@@ -1010,6 +1014,7 @@ fn test_init_data() {
             ParamsOfDecodeInitialData {
                 abi: Some(abi.clone()),
                 data: result.data,
+                allow_partial: false,
             },
         )
         .unwrap();

--- a/ton_client/src/debot/dengine.rs
+++ b/ton_client/src/debot/dengine.rs
@@ -583,6 +583,7 @@ impl DEngine {
                 abi: abi.clone(),
                 body: body.to_string(),
                 is_internal: true,
+                allow_partial: false,
             },
         )
         .await

--- a/ton_client/src/debot/dinterface.rs
+++ b/ton_client/src/debot/dinterface.rs
@@ -30,7 +30,7 @@ async fn decode_msg(
     let abi = AbiContract::load(abi.as_bytes()).map_err(|e| Error::invalid_json(e))?;
     let (_, body) = deserialize_cell_from_boc(&client, &msg_body, "message body").await?;
     let body: SliceData = body.into();
-    let input = abi.decode_input(body, true)
+    let input = abi.decode_input(body, true, false)
         .map_err(|e| Error::invalid_message_for_decode(e))?;
     let value = Detokenizer::detokenize_to_json_value(&input.tokens)
         .map_err(|e| Error::invalid_message_for_decode(e))?;

--- a/ton_client/src/debot/msg_interface.rs
+++ b/ton_client/src/debot/msg_interface.rs
@@ -105,6 +105,7 @@ impl MsgInterface {
             ParamsOfDecodeMessage {
                 abi: self.debot_abi.clone(),
                 message: answer_msg,
+                allow_partial: false,
             },
         )
         .await
@@ -146,6 +147,7 @@ impl MsgInterface {
             ParamsOfDecodeMessage {
                 abi: self.debot_abi.clone(),
                 message: answer_msg,
+                allow_partial: false,
             },
         )
         .await

--- a/ton_client/src/debot/tests.rs
+++ b/ton_client/src/debot/tests.rs
@@ -384,7 +384,7 @@ impl TestBrowser {
                 };
                 let decoded: DecodedMessageBody = client.request_async(
                     "abi.decode_message_body",
-                    ParamsOfDecodeMessageBody { abi, body, is_internal: true },
+                    ParamsOfDecodeMessageBody { abi, body, is_internal: true, allow_partial: false },
                 ).await.unwrap();
                 let (func, args) = (decoded.name, decoded.value.unwrap());
                 log::info!("request: {} ({})", func, args);

--- a/ton_client/src/net/transaction_tree.rs
+++ b/ton_client/src/net/transaction_tree.rs
@@ -126,6 +126,7 @@ impl MessageNode {
                                 body: body.to_string(),
                                 abi: abi.clone(),
                                 is_internal,
+                                allow_partial: false,
                             },
                         )
                         .await

--- a/ton_client/src/processing/internal.rs
+++ b/ton_client/src/processing/internal.rs
@@ -57,6 +57,7 @@ pub(crate) async fn get_message_expiration_time(
             ParamsOfDecodeMessage {
                 abi: abi.clone(),
                 message: message.to_string(),
+                allow_partial: false,
             },
         )
         .await

--- a/ton_client/src/processing/parsing.rs
+++ b/ton_client/src/processing/parsing.rs
@@ -41,6 +41,7 @@ pub(crate) async fn decode_output(
             ParamsOfDecodeMessage {
                 message,
                 abi: abi.clone(),
+                allow_partial: false,
             },
         ).await;
         let decoded = match decode_result {

--- a/ton_sdk/src/contract.rs
+++ b/ton_sdk/src/contract.rs
@@ -214,8 +214,9 @@ impl Contract {
         function: String,
         response: SliceData,
         internal: bool,
+        allow_partial: bool,
     ) -> Result<String> {
-        ton_abi::json_abi::decode_function_response(abi, function, response, internal)
+        ton_abi::json_abi::decode_function_response(abi, function, response, internal, allow_partial)
     }
 
     /// Decodes output parameters returned by contract function call from serialized message body
@@ -224,10 +225,11 @@ impl Contract {
         function: String,
         response: &[u8],
         internal: bool,
+        allow_partial: bool,
     ) -> Result<String> {
         let slice = Self::deserialize_tree_to_slice(response)?;
 
-        Self::decode_function_response_json(abi, function, slice, internal)
+        Self::decode_function_response_json(abi, function, slice, internal, allow_partial)
     }
 
     /// Decodes output parameters returned by contract function call
@@ -235,8 +237,9 @@ impl Contract {
         abi: String,
         response: SliceData,
         internal: bool,
+        allow_partial: bool,
     ) -> Result<DecodedMessage> {
-        ton_abi::json_abi::decode_unknown_function_response(abi, response, internal)
+        ton_abi::json_abi::decode_unknown_function_response(abi, response, internal, allow_partial)
     }
 
     /// Decodes output parameters returned by contract function call from serialized message body
@@ -244,10 +247,11 @@ impl Contract {
         abi: String,
         response: &[u8],
         internal: bool,
+        allow_partial: bool,
     ) -> Result<DecodedMessage> {
         let slice = Self::deserialize_tree_to_slice(response)?;
 
-        Self::decode_unknown_function_response_json(abi, slice, internal)
+        Self::decode_unknown_function_response_json(abi, slice, internal, allow_partial)
     }
 
     /// Decodes output parameters returned by contract function call
@@ -255,8 +259,9 @@ impl Contract {
         abi: String,
         response: SliceData,
         internal: bool,
+        allow_partial: bool,
     ) -> Result<DecodedMessage> {
-        ton_abi::json_abi::decode_unknown_function_call(abi, response, internal)
+        ton_abi::json_abi::decode_unknown_function_call(abi, response, internal, allow_partial)
     }
 
     /// Decodes output parameters returned by contract function call from serialized message body
@@ -264,10 +269,11 @@ impl Contract {
         abi: String,
         response: &[u8],
         internal: bool,
+        allow_partial: bool,
     ) -> Result<DecodedMessage> {
         let slice = Self::deserialize_tree_to_slice(response)?;
 
-        Self::decode_unknown_function_call_json(abi, slice, internal)
+        Self::decode_unknown_function_call_json(abi, slice, internal, allow_partial)
     }
 
     // ------- Call constructing functions -------


### PR DESCRIPTION
- `allow_partial` flag in all `abi.decode_*` functions. This flag controls decoder behaviour whether return error or not in case of incomplete BOC decoding