### PR TITLE
Remp support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### New 
 
 - `allow_partial` flag in all `abi.decode_*` functions. This flag controls decoder behaviour whether return error or not in case of incomplete BOC decoding
+- `REMP` supported. `ProcessingEvent` enum provided from `processing.wait_for_transaction` function callback is extended with `REMP` statuses 
 
 ## [1.32.0] – 2022-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.33.0] – 2022-04-01
+
+### New 
+
+- `allow_partial` flag in all `abi.decode_*` functions. This flag controls decoder behaviour whether return error or not in case of incomplete BOC decoding
+
 ## [1.32.0] – 2022-03-22
 
 ### New 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ members = [
     'api/test',
     'tools/update_trusted_blocks'
 ]
+
+[patch.'https://github.com/tonlabs/ton-labs-abi.git']
+ton_abi = { git = 'https://github.com/tonlabs//ton-labs-abi.git', branch = "allow-partial-decode" }

--- a/ton_client/Cargo.toml
+++ b/ton_client/Cargo.toml
@@ -20,12 +20,12 @@ api_derive = { path = '../api/derive' }
 api_info = { path = '../api/info' }
 ton_sdk = { default-features = false, path = '../ton_sdk' }
 
-ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', tag = '2.1.14' }
-ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.39' }
-ton_block_json = { git = 'https://github.com/tonlabs/ton-labs-block-json.git', tag = '0.7.5' }
-ton_executor = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-executor.git', tag = '1.15.57' }
-ton_types = { git = 'https://github.com/tonlabs/ton-labs-types.git', tag = '1.10.12' }
-ton_vm = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-vm.git', tag = '1.8.32' }
+ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', branch = 'allow-partial-decode' }
+ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.43' }
+ton_block_json = { git = 'https://github.com/tonlabs/ton-labs-block-json.git', tag = '0.7.10' }
+ton_executor = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-executor.git', tag = '1.15.63' }
+ton_types = { git = 'https://github.com/tonlabs/ton-labs-types.git', tag = '1.10.14' }
+ton_vm = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-vm.git', tag = '1.8.33' }
 
 lockfree = { git = 'https://github.com/tonlabs/lockfree.git', package = 'lockfree' }
 sodalite = { features = [ 'rand' ], git = 'https://github.com/tonlabs/sodalite.git' }

--- a/ton_client/Cargo.toml
+++ b/ton_client/Cargo.toml
@@ -20,7 +20,7 @@ api_derive = { path = '../api/derive' }
 api_info = { path = '../api/info' }
 ton_sdk = { default-features = false, path = '../ton_sdk' }
 
-ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', branch = 'allow-partial-decode' }
+ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', tag = '2.2.0' }
 ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.43' }
 ton_block_json = { git = 'https://github.com/tonlabs/ton-labs-block-json.git', tag = '0.7.10' }
 ton_executor = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-executor.git', tag = '1.15.63' }

--- a/ton_client/src/abi/decode_data.rs
+++ b/ton_client/src/abi/decode_data.rs
@@ -15,6 +15,13 @@ pub struct ParamsOfDecodeAccountData {
 
     /// Data BOC or BOC handle
     pub data: String,
+
+    /// Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC.
+    /// Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC:
+    /// `true` - return decoded values
+    /// `false` - return error of incomplete BOC deserialization (default)
+    #[serde(default)]
+    pub allow_partial: bool,
 }
 
 #[derive(Serialize, Deserialize, ApiType, Default)]
@@ -34,7 +41,7 @@ pub async fn decode_account_data(
     let (_, data) = deserialize_cell_from_boc(&context, &params.data, "contract data").await?;
     let abi = params.abi.abi()?;
 
-    let tokens = abi.decode_storage_fields(data.into())
+    let tokens = abi.decode_storage_fields(data.into(), params.allow_partial)
         .map_err(|e| Error::invalid_data_for_decode(e))?;
 
     let data = Detokenizer::detokenize_to_json_value(&tokens)

--- a/ton_client/src/abi/init_data.rs
+++ b/ton_client/src/abi/init_data.rs
@@ -124,6 +124,12 @@ pub struct ParamsOfDecodeInitialData  {
     pub abi: Option<Abi>,
     /// Data BOC or BOC handle
     pub data: String,
+    /// Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC.
+    /// Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC:
+    /// `true` - return decoded values
+    /// `false` - return error of incomplete BOC deserialization (default)
+    #[serde(default)]
+    pub allow_partial: bool,
 }
 
 #[derive(Serialize, Deserialize, ApiType, Default)]
@@ -152,7 +158,7 @@ pub async fn decode_initial_data(
     let initial_data = if let Some(abi) = params.abi {
         let abi = abi.abi()?;
 
-        let tokens = abi.decode_data(data)
+        let tokens = abi.decode_data(data, params.allow_partial)
             .map_err(|e| Error::invalid_data_for_decode(e))?;
 
         let initial_data = ton_abi::token::Detokenizer::detokenize_to_json_value(&tokens)

--- a/ton_client/src/abi/tests.rs
+++ b/ton_client/src/abi/tests.rs
@@ -301,6 +301,7 @@ fn decode_v2() {
                 ParamsOfDecodeMessage {
                     abi: events_abi.clone(),
                     message: message.into(),
+                    allow_partial: false,
                 },
             )
             .unwrap();
@@ -320,6 +321,7 @@ fn decode_v2() {
                     abi: events_abi.clone(),
                     body,
                     is_internal: parsed.parsed["msg_type_name"] == "Internal",
+                    allow_partial: false,
                 },
             )
             .unwrap();
@@ -354,6 +356,7 @@ fn decode_v2() {
         abi: events_abi.clone(),
         body: "te6ccgEBAgEAlgAB4a3f2/jCeWWvgMoAXOakv3VSD56sQrDPT76n1cbrSvpZ0BCs0KEUy2Duvo3zPExePONW3TYy0MCA1i+FFRXcSIXTHxAj/Hd67jWQF7peccWoU/dbMCBJBB6YdPCVZcJlJkAAAF0ZyXLg19VzGQVviwSgAQBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=".into(),
         is_internal: false,
+        allow_partial: false,
     }).unwrap();
     let expected = DecodedMessageBody {
         body_type: MessageBodyType::Input,
@@ -914,7 +917,7 @@ fn test_decode_account_data() {
     let client = TestClient::new();
     let decoded = client.request::<_, ResultOfDecodeAccountData>(
         "abi.decode_account_data",
-        ParamsOfDecodeAccountData { data, abi },
+        ParamsOfDecodeAccountData { data, abi, allow_partial: false, },
     )
     .unwrap()
     .data;
@@ -962,6 +965,7 @@ fn test_init_data() {
             ParamsOfDecodeInitialData {
                 abi: Some(abi.clone()),
                 data: data.clone(),
+                allow_partial: false,
             },
         )
         .unwrap();
@@ -1010,6 +1014,7 @@ fn test_init_data() {
             ParamsOfDecodeInitialData {
                 abi: Some(abi.clone()),
                 data: result.data,
+                allow_partial: false,
             },
         )
         .unwrap();

--- a/ton_client/src/debot/dengine.rs
+++ b/ton_client/src/debot/dengine.rs
@@ -583,6 +583,7 @@ impl DEngine {
                 abi: abi.clone(),
                 body: body.to_string(),
                 is_internal: true,
+                allow_partial: false,
             },
         )
         .await

--- a/ton_client/src/debot/dinterface.rs
+++ b/ton_client/src/debot/dinterface.rs
@@ -30,7 +30,7 @@ async fn decode_msg(
     let abi = AbiContract::load(abi.as_bytes()).map_err(|e| Error::invalid_json(e))?;
     let (_, body) = deserialize_cell_from_boc(&client, &msg_body, "message body").await?;
     let body: SliceData = body.into();
-    let input = abi.decode_input(body, true)
+    let input = abi.decode_input(body, true, false)
         .map_err(|e| Error::invalid_message_for_decode(e))?;
     let value = Detokenizer::detokenize_to_json_value(&input.tokens)
         .map_err(|e| Error::invalid_message_for_decode(e))?;

--- a/ton_client/src/debot/msg_interface.rs
+++ b/ton_client/src/debot/msg_interface.rs
@@ -105,6 +105,7 @@ impl MsgInterface {
             ParamsOfDecodeMessage {
                 abi: self.debot_abi.clone(),
                 message: answer_msg,
+                allow_partial: false,
             },
         )
         .await
@@ -146,6 +147,7 @@ impl MsgInterface {
             ParamsOfDecodeMessage {
                 abi: self.debot_abi.clone(),
                 message: answer_msg,
+                allow_partial: false,
             },
         )
         .await

--- a/ton_client/src/debot/tests.rs
+++ b/ton_client/src/debot/tests.rs
@@ -384,7 +384,7 @@ impl TestBrowser {
                 };
                 let decoded: DecodedMessageBody = client.request_async(
                     "abi.decode_message_body",
-                    ParamsOfDecodeMessageBody { abi, body, is_internal: true },
+                    ParamsOfDecodeMessageBody { abi, body, is_internal: true, allow_partial: false },
                 ).await.unwrap();
                 let (func, args) = (decoded.name, decoded.value.unwrap());
                 log::info!("request: {} ({})", func, args);

--- a/ton_client/src/error.rs
+++ b/ton_client/src/error.rs
@@ -27,7 +27,7 @@ pub(crate) trait AddNetworkUrl: Sized {
     }
 
     async fn add_network_url(self, client: &crate::net::ServerLink) -> Self {
-        self.add_network_url_from_state(client.state().await.as_ref()).await
+        self.add_network_url_from_state(client.state().as_ref()).await
     }
 
     async fn add_network_url_from_context(self, client: &crate::ClientContext) -> Self {

--- a/ton_client/src/net/server_link.rs
+++ b/ton_client/src/net/server_link.rs
@@ -416,7 +416,7 @@ impl ServerLink {
         self.state.config_servers().await
     }
 
-    pub async fn state(&self) -> Arc<NetworkState> {
+    pub fn state(&self) -> Arc<NetworkState> {
         self.state.clone()
     }
 
@@ -715,7 +715,7 @@ impl ServerLink {
         &self,
         key: &[u8],
         value: &[u8],
-        endpoint: Option<Endpoint>,
+        endpoint: Option<&Endpoint>,
     ) -> ClientResult<Option<ClientError>> {
         let request = PostRequest {
             id: base64::encode(key),
@@ -727,7 +727,7 @@ impl ServerLink {
         let result = self
             .query(
                 &GraphQLQuery::with_post_requests(&[request]),
-                endpoint.as_ref(),
+                endpoint,
             )
             .await;
 

--- a/ton_client/src/net/transaction_tree.rs
+++ b/ton_client/src/net/transaction_tree.rs
@@ -126,6 +126,7 @@ impl MessageNode {
                                 body: body.to_string(),
                                 abi: abi.clone(),
                                 is_internal,
+                                allow_partial: false,
                             },
                         )
                         .await

--- a/ton_client/src/processing/errors.rs
+++ b/ton_client/src/processing/errors.rs
@@ -31,6 +31,9 @@ pub enum ErrorCode {
     BlockNotFound = 511,
     InvalidData = 512,
     ExternalSignerMustNotBeUsed = 513,
+    MessageRejected = 514,
+    InvalidRempStatus = 515,
+    NextRempStatusTimeout = 516,
 }
 
 pub struct Error;
@@ -145,7 +148,7 @@ impl Error {
     pub fn fetch_transaction_result_failed<E: std::fmt::Display>(
         err: E,
         message_id: &str,
-        shard_block_id: &String,
+        shard_block_id: &str,
     ) -> ClientError {
         Self::processing_error(
             ErrorCode::InvalidBlockReceived,
@@ -157,7 +160,7 @@ impl Error {
 
     pub fn message_expired(
         message_id: &str,
-        shard_block_id: &String,
+        shard_block_id: &str,
         expiration_time: u32,
         block_time: u32,
         address: &MsgAddressInt,
@@ -212,5 +215,22 @@ impl Error {
 
     pub fn invalid_data<E: std::fmt::Display>(err: E) -> ClientError {
         error(ErrorCode::InvalidData, format!("Invalid data: {}", err))
+    }
+
+    pub fn message_rejected(message_id: &str, err: &str) -> ClientError {
+        Self::processing_error(
+            ErrorCode::MessageRejected,
+            format!("message has been rejected: {}", err),
+            message_id,
+            None,
+        )
+    }
+
+    pub fn invalid_remp_status<E: std::fmt::Display>(err: E) -> ClientError {
+        error(ErrorCode::InvalidRempStatus, format!("Invalid REMP status: {}", err))
+    }
+
+    pub fn next_remp_status_timeout() -> ClientError {
+        error(ErrorCode::NextRempStatusTimeout, format!("Next REMP status awaiting timeout"))
     }
 }

--- a/ton_client/src/processing/internal.rs
+++ b/ton_client/src/processing/internal.rs
@@ -57,6 +57,7 @@ pub(crate) async fn get_message_expiration_time(
             ParamsOfDecodeMessage {
                 abi: abi.clone(),
                 message: message.to_string(),
+                allow_partial: false,
             },
         )
         .await

--- a/ton_client/src/processing/mod.rs
+++ b/ton_client/src/processing/mod.rs
@@ -21,6 +21,7 @@ mod fetching;
 mod internal;
 pub(crate) mod parsing;
 pub(crate) mod process_message;
+mod remp;
 pub(crate) mod send_message;
 mod types;
 pub(crate) mod wait_for_transaction;

--- a/ton_client/src/processing/parsing.rs
+++ b/ton_client/src/processing/parsing.rs
@@ -41,6 +41,7 @@ pub(crate) async fn decode_output(
             ParamsOfDecodeMessage {
                 message,
                 abi: abi.clone(),
+                allow_partial: false,
             },
         ).await;
         let decoded = match decode_result {

--- a/ton_client/src/processing/remp.rs
+++ b/ton_client/src/processing/remp.rs
@@ -1,0 +1,60 @@
+use super::ProcessingEvent;
+
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RempStatusData {
+    pub message_id: String,
+    pub timestamp: u64,
+    #[serde(deserialize_with = "deserialize_json_from_string")]
+    pub json: serde_json::Value,
+}
+
+pub fn deserialize_json_from_string<'de, D>(d: D) -> Result<serde_json::Value, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let string = d.deserialize_option(ton_sdk::json_helper::StringVisitor)?;
+
+    if "null" == string {
+        Ok(serde_json::Value::Null)
+    } else {
+        Ok(serde_json::from_str(&string).map_err(|err| serde::de::Error::custom(err))?)
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(tag = "kind")]
+pub enum RempStatus {
+    RejectedByFullnode(RempStatusData),
+    SentToValidators(RempStatusData),
+    IncludedIntoBlock(RempStatusData),
+    IncludedIntoAcceptedBlock(RempStatusData),
+    Finalized(RempStatusData),
+    Other(RempStatusData),
+}
+
+impl Into<ProcessingEvent> for RempStatus {
+    fn into(self) -> ProcessingEvent {
+        match self {
+            RempStatus::SentToValidators(data) => {
+                ProcessingEvent::RempSentToValidators { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+            },
+            RempStatus::IncludedIntoBlock(data) => {
+                ProcessingEvent::RempIncludedIntoBlock { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+            },
+            RempStatus::IncludedIntoAcceptedBlock(data) => {
+                ProcessingEvent::RempIncludedIntoAcceptedBlock { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+            },
+            RempStatus::Other(data) => {
+                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+            },
+            RempStatus::RejectedByFullnode(data) => {
+                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+            },
+            RempStatus::Finalized(data) => {
+                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+            },
+        }
+    }
+}

--- a/ton_client/src/processing/remp.rs
+++ b/ton_client/src/processing/remp.rs
@@ -38,22 +38,22 @@ impl Into<ProcessingEvent> for RempStatus {
     fn into(self) -> ProcessingEvent {
         match self {
             RempStatus::SentToValidators(data) => {
-                ProcessingEvent::RempSentToValidators { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+                ProcessingEvent::RempSentToValidators { message_id: data.message_id, timestamp: data.timestamp, json: data.json }
             },
             RempStatus::IncludedIntoBlock(data) => {
-                ProcessingEvent::RempIncludedIntoBlock { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+                ProcessingEvent::RempIncludedIntoBlock { message_id: data.message_id, timestamp: data.timestamp, json: data.json }
             },
             RempStatus::IncludedIntoAcceptedBlock(data) => {
-                ProcessingEvent::RempIncludedIntoAcceptedBlock { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+                ProcessingEvent::RempIncludedIntoAcceptedBlock { message_id: data.message_id, timestamp: data.timestamp, json: data.json }
             },
             RempStatus::Other(data) => {
-                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: data.timestamp, json: data.json }
             },
             RempStatus::RejectedByFullnode(data) => {
-                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: data.timestamp, json: data.json }
             },
             RempStatus::Finalized(data) => {
-                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: data.timestamp, json: data.json }
             },
         }
     }

--- a/ton_client/src/processing/types.rs
+++ b/ton_client/src/processing/types.rs
@@ -141,4 +141,28 @@ pub enum ProcessingEvent {
         message: String,
         error: ClientError,
     },
+
+    RempSentToValidators {
+        message_id: String,
+        timestamp: u64,
+        json: Value,
+    },
+    RempIncludedIntoBlock {
+        message_id: String,
+        timestamp: u64,
+        json: Value,
+    },
+    RempIncludedIntoAcceptedBlock {
+        message_id: String,
+        timestamp: u64,
+        json: Value,
+    },
+    RempOther {
+        message_id: String,
+        timestamp: u64,
+        json: Value,
+    },
+    RempError {
+        error: ClientError,
+    }
 }

--- a/ton_client/src/processing/types.rs
+++ b/ton_client/src/processing/types.rs
@@ -142,26 +142,32 @@ pub enum ProcessingEvent {
         error: ClientError,
     },
 
+    /// Notifies the app that the message has been sent to shardchain validators by fullnode
     RempSentToValidators {
         message_id: String,
         timestamp: u64,
         json: Value,
     },
+    /// Notifies the app that the message has been included into collated shrdchain block by some validator
     RempIncludedIntoBlock {
         message_id: String,
         timestamp: u64,
         json: Value,
     },
+    /// Notifies the app that the block the message was included to was accepted by shardchain validators
     RempIncludedIntoAcceptedBlock {
         message_id: String,
         timestamp: u64,
         json: Value,
     },
+    /// Notifies the app about some other minor REMP statuses occured during message processing
     RempOther {
         message_id: String,
         timestamp: u64,
         json: Value,
     },
+    /// Notifies the app about error occured during REMP status processing. When any error occured 
+    /// fallback transaction awaiting scenario is activated
     RempError {
         error: ClientError,
     }

--- a/ton_client/src/processing/wait_for_transaction.rs
+++ b/ton_client/src/processing/wait_for_transaction.rs
@@ -173,7 +173,6 @@ async fn process_remp_message<F: futures::Future<Output = ()> + Send>(
     remp_message: ClientResult<serde_json::Value>,
 ) -> ClientResult<Option<ClientResult<ResultOfProcessMessage>>> {
     let remp_message = remp_message?;
-    println!("process_remp_message {} {:#}", chrono::prelude::Utc::now().timestamp_millis(), remp_message);
     let status: RempStatus = serde_json::from_value(remp_message)
         .map_err(|err| Error::invalid_remp_status(format!("can not parse REMP status message: {}", err)))?;
 

--- a/ton_sdk/Cargo.toml
+++ b/ton_sdk/Cargo.toml
@@ -6,7 +6,7 @@ license = 'Apache-2.0'
 authors = [ 'TON Labs LTD <support@tonlabs.io>' ]
 
 [dependencies]
-ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', branch = 'allow-partial-decode' }
+ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', tag = '2.2.0' }
 ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.43' }
 ton_vm = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-vm.git', tag = '1.8.33' }
 ton_types = { git = 'https://github.com/tonlabs/ton-labs-types.git', tag = '1.10.14' }

--- a/ton_sdk/Cargo.toml
+++ b/ton_sdk/Cargo.toml
@@ -6,10 +6,10 @@ license = 'Apache-2.0'
 authors = [ 'TON Labs LTD <support@tonlabs.io>' ]
 
 [dependencies]
-ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', tag = '2.1.14' }
-ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.39' }
-ton_vm = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-vm.git', tag = '1.8.32' }
-ton_types = { git = 'https://github.com/tonlabs/ton-labs-types.git', tag = '1.10.12' }
+ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', branch = 'allow-partial-decode' }
+ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.43' }
+ton_vm = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-vm.git', tag = '1.8.33' }
+ton_types = { git = 'https://github.com/tonlabs/ton-labs-types.git', tag = '1.10.14' }
 
 api_info = { path = '../api/info' }
 api_derive = { path = '../api/derive' }

--- a/ton_sdk/src/contract.rs
+++ b/ton_sdk/src/contract.rs
@@ -214,8 +214,9 @@ impl Contract {
         function: String,
         response: SliceData,
         internal: bool,
+        allow_partial: bool,
     ) -> Result<String> {
-        ton_abi::json_abi::decode_function_response(abi, function, response, internal)
+        ton_abi::json_abi::decode_function_response(abi, function, response, internal, allow_partial)
     }
 
     /// Decodes output parameters returned by contract function call from serialized message body
@@ -224,10 +225,11 @@ impl Contract {
         function: String,
         response: &[u8],
         internal: bool,
+        allow_partial: bool,
     ) -> Result<String> {
         let slice = Self::deserialize_tree_to_slice(response)?;
 
-        Self::decode_function_response_json(abi, function, slice, internal)
+        Self::decode_function_response_json(abi, function, slice, internal, allow_partial)
     }
 
     /// Decodes output parameters returned by contract function call
@@ -235,8 +237,9 @@ impl Contract {
         abi: String,
         response: SliceData,
         internal: bool,
+        allow_partial: bool,
     ) -> Result<DecodedMessage> {
-        ton_abi::json_abi::decode_unknown_function_response(abi, response, internal)
+        ton_abi::json_abi::decode_unknown_function_response(abi, response, internal, allow_partial)
     }
 
     /// Decodes output parameters returned by contract function call from serialized message body
@@ -244,10 +247,11 @@ impl Contract {
         abi: String,
         response: &[u8],
         internal: bool,
+        allow_partial: bool,
     ) -> Result<DecodedMessage> {
         let slice = Self::deserialize_tree_to_slice(response)?;
 
-        Self::decode_unknown_function_response_json(abi, slice, internal)
+        Self::decode_unknown_function_response_json(abi, slice, internal, allow_partial)
     }
 
     /// Decodes output parameters returned by contract function call
@@ -255,8 +259,9 @@ impl Contract {
         abi: String,
         response: SliceData,
         internal: bool,
+        allow_partial: bool,
     ) -> Result<DecodedMessage> {
-        ton_abi::json_abi::decode_unknown_function_call(abi, response, internal)
+        ton_abi::json_abi::decode_unknown_function_call(abi, response, internal, allow_partial)
     }
 
     /// Decodes output parameters returned by contract function call from serialized message body
@@ -264,10 +269,11 @@ impl Contract {
         abi: String,
         response: &[u8],
         internal: bool,
+        allow_partial: bool,
     ) -> Result<DecodedMessage> {
         let slice = Self::deserialize_tree_to_slice(response)?;
 
-        Self::decode_unknown_function_call_json(abi, slice, internal)
+        Self::decode_unknown_function_call_json(abi, slice, internal, allow_partial)
     }
 
     // ------- Call constructing functions -------

--- a/ton_sdk/src/json_helper.rs
+++ b/ton_sdk/src/json_helper.rs
@@ -20,7 +20,7 @@ use ton_block::{
 };
 use ton_types::Cell;
 
-struct StringVisitor;
+pub struct StringVisitor;
 
 impl<'de> serde::de::Visitor<'de> for StringVisitor {
     type Value = String;


### PR DESCRIPTION
- `REMP` supported. `ProcessingEvent` enum provided from `processing.wait_for_transaction` function callback is extended with `REMP` statuses 