### PR TITLE
Remp support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### New 
 
 - `allow_partial` flag in all `abi.decode_*` functions. This flag controls decoder behaviour whether return error or not in case of incomplete BOC decoding
+- `REMP` supported. `ProcessingEvent` enum provided from `processing.wait_for_transaction` function callback is extended with `REMP` statuses 
 
 ## [1.32.0] – 2022-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### New 
 
 - `allow_partial` flag in all `abi.decode_*` functions. This flag controls decoder behaviour whether return error or not in case of incomplete BOC decoding
-- `REMP` supported. `ProcessingEvent` enum provided from `processing.wait_for_transaction` function callback is extended with `REMP` statuses 
+- `REMP` supported. `ProcessingEvent` enum is extended with `REMP` statuses (enum of events posted into `processing.wait_for_transaction` function callback )
 
 ## [1.32.0] – 2022-03-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ members = [
     'api/test',
     'tools/update_trusted_blocks'
 ]
+
+[patch.'https://github.com/tonlabs/ton-labs-abi.git']
+ton_abi = { git = 'https://github.com/tonlabs//ton-labs-abi.git', branch = "allow-partial-decode" }

--- a/ton_client/Cargo.toml
+++ b/ton_client/Cargo.toml
@@ -20,12 +20,12 @@ api_derive = { path = '../api/derive' }
 api_info = { path = '../api/info' }
 ton_sdk = { default-features = false, path = '../ton_sdk' }
 
-ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', tag = '2.1.14' }
-ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.39' }
-ton_block_json = { git = 'https://github.com/tonlabs/ton-labs-block-json.git', tag = '0.7.5' }
-ton_executor = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-executor.git', tag = '1.15.57' }
-ton_types = { git = 'https://github.com/tonlabs/ton-labs-types.git', tag = '1.10.12' }
-ton_vm = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-vm.git', tag = '1.8.32' }
+ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', branch = 'allow-partial-decode' }
+ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.43' }
+ton_block_json = { git = 'https://github.com/tonlabs/ton-labs-block-json.git', tag = '0.7.10' }
+ton_executor = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-executor.git', tag = '1.15.63' }
+ton_types = { git = 'https://github.com/tonlabs/ton-labs-types.git', tag = '1.10.14' }
+ton_vm = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-vm.git', tag = '1.8.33' }
 
 lockfree = { git = 'https://github.com/tonlabs/lockfree.git', package = 'lockfree' }
 sodalite = { features = [ 'rand' ], git = 'https://github.com/tonlabs/sodalite.git' }

--- a/ton_client/Cargo.toml
+++ b/ton_client/Cargo.toml
@@ -20,7 +20,7 @@ api_derive = { path = '../api/derive' }
 api_info = { path = '../api/info' }
 ton_sdk = { default-features = false, path = '../ton_sdk' }
 
-ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', branch = 'allow-partial-decode' }
+ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', tag = '2.2.0' }
 ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.43' }
 ton_block_json = { git = 'https://github.com/tonlabs/ton-labs-block-json.git', tag = '0.7.10' }
 ton_executor = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-executor.git', tag = '1.15.63' }

--- a/ton_client/src/error.rs
+++ b/ton_client/src/error.rs
@@ -27,7 +27,7 @@ pub(crate) trait AddNetworkUrl: Sized {
     }
 
     async fn add_network_url(self, client: &crate::net::ServerLink) -> Self {
-        self.add_network_url_from_state(client.state().await.as_ref()).await
+        self.add_network_url_from_state(client.state().as_ref()).await
     }
 
     async fn add_network_url_from_context(self, client: &crate::ClientContext) -> Self {

--- a/ton_client/src/net/server_link.rs
+++ b/ton_client/src/net/server_link.rs
@@ -416,7 +416,7 @@ impl ServerLink {
         self.state.config_servers().await
     }
 
-    pub async fn state(&self) -> Arc<NetworkState> {
+    pub fn state(&self) -> Arc<NetworkState> {
         self.state.clone()
     }
 
@@ -715,7 +715,7 @@ impl ServerLink {
         &self,
         key: &[u8],
         value: &[u8],
-        endpoint: Option<Endpoint>,
+        endpoint: Option<&Endpoint>,
     ) -> ClientResult<Option<ClientError>> {
         let request = PostRequest {
             id: base64::encode(key),
@@ -727,7 +727,7 @@ impl ServerLink {
         let result = self
             .query(
                 &GraphQLQuery::with_post_requests(&[request]),
-                endpoint.as_ref(),
+                endpoint,
             )
             .await;
 

--- a/ton_client/src/processing/errors.rs
+++ b/ton_client/src/processing/errors.rs
@@ -31,6 +31,9 @@ pub enum ErrorCode {
     BlockNotFound = 511,
     InvalidData = 512,
     ExternalSignerMustNotBeUsed = 513,
+    MessageRejected = 514,
+    InvalidRempStatus = 515,
+    NextRempStatusTimeout = 516,
 }
 
 pub struct Error;
@@ -145,7 +148,7 @@ impl Error {
     pub fn fetch_transaction_result_failed<E: std::fmt::Display>(
         err: E,
         message_id: &str,
-        shard_block_id: &String,
+        shard_block_id: &str,
     ) -> ClientError {
         Self::processing_error(
             ErrorCode::InvalidBlockReceived,
@@ -157,7 +160,7 @@ impl Error {
 
     pub fn message_expired(
         message_id: &str,
-        shard_block_id: &String,
+        shard_block_id: &str,
         expiration_time: u32,
         block_time: u32,
         address: &MsgAddressInt,
@@ -212,5 +215,22 @@ impl Error {
 
     pub fn invalid_data<E: std::fmt::Display>(err: E) -> ClientError {
         error(ErrorCode::InvalidData, format!("Invalid data: {}", err))
+    }
+
+    pub fn message_rejected(message_id: &str, err: &str) -> ClientError {
+        Self::processing_error(
+            ErrorCode::MessageRejected,
+            format!("message has been rejected: {}", err),
+            message_id,
+            None,
+        )
+    }
+
+    pub fn invalid_remp_status<E: std::fmt::Display>(err: E) -> ClientError {
+        error(ErrorCode::InvalidRempStatus, format!("Invalid REMP status: {}", err))
+    }
+
+    pub fn next_remp_status_timeout() -> ClientError {
+        error(ErrorCode::NextRempStatusTimeout, format!("Next REMP status awaiting timeout"))
     }
 }

--- a/ton_client/src/processing/mod.rs
+++ b/ton_client/src/processing/mod.rs
@@ -21,6 +21,7 @@ mod fetching;
 mod internal;
 pub(crate) mod parsing;
 pub(crate) mod process_message;
+mod remp;
 pub(crate) mod send_message;
 mod types;
 pub(crate) mod wait_for_transaction;

--- a/ton_client/src/processing/remp.rs
+++ b/ton_client/src/processing/remp.rs
@@ -1,0 +1,60 @@
+use super::ProcessingEvent;
+
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RempStatusData {
+    pub message_id: String,
+    pub timestamp: u64,
+    #[serde(deserialize_with = "deserialize_json_from_string")]
+    pub json: serde_json::Value,
+}
+
+pub fn deserialize_json_from_string<'de, D>(d: D) -> Result<serde_json::Value, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let string = d.deserialize_option(ton_sdk::json_helper::StringVisitor)?;
+
+    if "null" == string {
+        Ok(serde_json::Value::Null)
+    } else {
+        Ok(serde_json::from_str(&string).map_err(|err| serde::de::Error::custom(err))?)
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(tag = "kind")]
+pub enum RempStatus {
+    RejectedByFullnode(RempStatusData),
+    SentToValidators(RempStatusData),
+    IncludedIntoBlock(RempStatusData),
+    IncludedIntoAcceptedBlock(RempStatusData),
+    Finalized(RempStatusData),
+    Other(RempStatusData),
+}
+
+impl Into<ProcessingEvent> for RempStatus {
+    fn into(self) -> ProcessingEvent {
+        match self {
+            RempStatus::SentToValidators(data) => {
+                ProcessingEvent::RempSentToValidators { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+            },
+            RempStatus::IncludedIntoBlock(data) => {
+                ProcessingEvent::RempIncludedIntoBlock { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+            },
+            RempStatus::IncludedIntoAcceptedBlock(data) => {
+                ProcessingEvent::RempIncludedIntoAcceptedBlock { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+            },
+            RempStatus::Other(data) => {
+                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+            },
+            RempStatus::RejectedByFullnode(data) => {
+                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+            },
+            RempStatus::Finalized(data) => {
+                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+            },
+        }
+    }
+}

--- a/ton_client/src/processing/remp.rs
+++ b/ton_client/src/processing/remp.rs
@@ -38,22 +38,22 @@ impl Into<ProcessingEvent> for RempStatus {
     fn into(self) -> ProcessingEvent {
         match self {
             RempStatus::SentToValidators(data) => {
-                ProcessingEvent::RempSentToValidators { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+                ProcessingEvent::RempSentToValidators { message_id: data.message_id, timestamp: data.timestamp, json: data.json }
             },
             RempStatus::IncludedIntoBlock(data) => {
-                ProcessingEvent::RempIncludedIntoBlock { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+                ProcessingEvent::RempIncludedIntoBlock { message_id: data.message_id, timestamp: data.timestamp, json: data.json }
             },
             RempStatus::IncludedIntoAcceptedBlock(data) => {
-                ProcessingEvent::RempIncludedIntoAcceptedBlock { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+                ProcessingEvent::RempIncludedIntoAcceptedBlock { message_id: data.message_id, timestamp: data.timestamp, json: data.json }
             },
             RempStatus::Other(data) => {
-                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: data.timestamp, json: data.json }
             },
             RempStatus::RejectedByFullnode(data) => {
-                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: data.timestamp, json: data.json }
             },
             RempStatus::Finalized(data) => {
-                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: chrono::prelude::Utc::now().timestamp_millis() as u64, json: data.json }
+                ProcessingEvent::RempOther { message_id: data.message_id, timestamp: data.timestamp, json: data.json }
             },
         }
     }

--- a/ton_client/src/processing/types.rs
+++ b/ton_client/src/processing/types.rs
@@ -142,32 +142,32 @@ pub enum ProcessingEvent {
         error: ClientError,
     },
 
-    /// Notifies the app that the message has been sent to shardchain validators by fullnode
+    /// Notifies the app that the message has been delivered to the thread's validators 
     RempSentToValidators {
         message_id: String,
         timestamp: u64,
         json: Value,
     },
-    /// Notifies the app that the message has been included into collated shrdchain block by some validator
+    /// Notifies the app that the message has been successfully included into a block candidate by the thread's collator
     RempIncludedIntoBlock {
         message_id: String,
         timestamp: u64,
         json: Value,
     },
-    /// Notifies the app that the block the message was included to was accepted by shardchain validators
+    /// Notifies the app that the block candicate with the message has been accepted by the thread's validators
     RempIncludedIntoAcceptedBlock {
         message_id: String,
         timestamp: u64,
         json: Value,
     },
-    /// Notifies the app about some other minor REMP statuses occured during message processing
+    /// Notifies the app about some other minor REMP statuses occurring during message processing
     RempOther {
         message_id: String,
         timestamp: u64,
         json: Value,
     },
-    /// Notifies the app about error occured during REMP status processing. When any error occured 
-    /// fallback transaction awaiting scenario is activated
+    /// Notifies the app about any problem that has occured in REMP processing - 
+    /// in this case library switches to the fallback transaction awaiting scenario (sequential block reading). 
     RempError {
         error: ClientError,
     }

--- a/ton_client/src/processing/types.rs
+++ b/ton_client/src/processing/types.rs
@@ -141,4 +141,28 @@ pub enum ProcessingEvent {
         message: String,
         error: ClientError,
     },
+
+    RempSentToValidators {
+        message_id: String,
+        timestamp: u64,
+        json: Value,
+    },
+    RempIncludedIntoBlock {
+        message_id: String,
+        timestamp: u64,
+        json: Value,
+    },
+    RempIncludedIntoAcceptedBlock {
+        message_id: String,
+        timestamp: u64,
+        json: Value,
+    },
+    RempOther {
+        message_id: String,
+        timestamp: u64,
+        json: Value,
+    },
+    RempError {
+        error: ClientError,
+    }
 }

--- a/ton_client/src/processing/types.rs
+++ b/ton_client/src/processing/types.rs
@@ -142,26 +142,32 @@ pub enum ProcessingEvent {
         error: ClientError,
     },
 
+    /// Notifies the app that the message has been sent to shardchain validators by fullnode
     RempSentToValidators {
         message_id: String,
         timestamp: u64,
         json: Value,
     },
+    /// Notifies the app that the message has been included into collated shrdchain block by some validator
     RempIncludedIntoBlock {
         message_id: String,
         timestamp: u64,
         json: Value,
     },
+    /// Notifies the app that the block the message was included to was accepted by shardchain validators
     RempIncludedIntoAcceptedBlock {
         message_id: String,
         timestamp: u64,
         json: Value,
     },
+    /// Notifies the app about some other minor REMP statuses occured during message processing
     RempOther {
         message_id: String,
         timestamp: u64,
         json: Value,
     },
+    /// Notifies the app about error occured during REMP status processing. When any error occured 
+    /// fallback transaction awaiting scenario is activated
     RempError {
         error: ClientError,
     }

--- a/ton_client/src/processing/wait_for_transaction.rs
+++ b/ton_client/src/processing/wait_for_transaction.rs
@@ -173,7 +173,6 @@ async fn process_remp_message<F: futures::Future<Output = ()> + Send>(
     remp_message: ClientResult<serde_json::Value>,
 ) -> ClientResult<Option<ClientResult<ResultOfProcessMessage>>> {
     let remp_message = remp_message?;
-    println!("process_remp_message {} {:#}", chrono::prelude::Utc::now().timestamp_millis(), remp_message);
     let status: RempStatus = serde_json::from_value(remp_message)
         .map_err(|err| Error::invalid_remp_status(format!("can not parse REMP status message: {}", err)))?;
 

--- a/ton_sdk/Cargo.toml
+++ b/ton_sdk/Cargo.toml
@@ -6,7 +6,7 @@ license = 'Apache-2.0'
 authors = [ 'TON Labs LTD <support@tonlabs.io>' ]
 
 [dependencies]
-ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', branch = 'allow-partial-decode' }
+ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', tag = '2.2.0' }
 ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.43' }
 ton_vm = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-vm.git', tag = '1.8.33' }
 ton_types = { git = 'https://github.com/tonlabs/ton-labs-types.git', tag = '1.10.14' }

--- a/ton_sdk/Cargo.toml
+++ b/ton_sdk/Cargo.toml
@@ -6,10 +6,10 @@ license = 'Apache-2.0'
 authors = [ 'TON Labs LTD <support@tonlabs.io>' ]
 
 [dependencies]
-ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', tag = '2.1.14' }
-ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.39' }
-ton_vm = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-vm.git', tag = '1.8.32' }
-ton_types = { git = 'https://github.com/tonlabs/ton-labs-types.git', tag = '1.10.12' }
+ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', branch = 'allow-partial-decode' }
+ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.43' }
+ton_vm = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-vm.git', tag = '1.8.33' }
+ton_types = { git = 'https://github.com/tonlabs/ton-labs-types.git', tag = '1.10.14' }
 
 api_info = { path = '../api/info' }
 api_derive = { path = '../api/derive' }

--- a/ton_sdk/src/json_helper.rs
+++ b/ton_sdk/src/json_helper.rs
@@ -20,7 +20,7 @@ use ton_block::{
 };
 use ton_types::Cell;
 
-struct StringVisitor;
+pub struct StringVisitor;
 
 impl<'de> serde::de::Visitor<'de> for StringVisitor {
     type Value = String;


### PR DESCRIPTION
- `REMP` supported. `ProcessingEvent` enum provided from `processing.wait_for_transaction` function callback is extended with `REMP` statuses 