### PR TITLE
Abi v2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+
+## [1.36.0] – 2022-07-01
+
+### New
+
+- ABI specification v2.3 is supported
+- parameter `address` is added to `abi.encode_message_body` function
+
 ## [1.35.1] – 2022-06-28
 
 ### Improved

--- a/ton_client/Cargo.toml
+++ b/ton_client/Cargo.toml
@@ -20,7 +20,7 @@ api_derive = { path = '../api/derive' }
 api_info = { path = '../api/info' }
 ton_sdk = { default-features = false, path = '../ton_sdk' }
 
-ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', branch = "abi-v2_3" }
+ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', tag = '2.3.0' }
 ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.51' }
 ton_block_json = { git = 'https://github.com/tonlabs/ton-labs-block-json.git', tag = '0.7.19' }
 ton_executor = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-executor.git', tag = '1.15.74' }

--- a/ton_client/Cargo.toml
+++ b/ton_client/Cargo.toml
@@ -20,7 +20,7 @@ api_derive = { path = '../api/derive' }
 api_info = { path = '../api/info' }
 ton_sdk = { default-features = false, path = '../ton_sdk' }
 
-ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', tag = '2.2.9' }
+ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', branch = "abi-v2_3" }
 ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.51' }
 ton_block_json = { git = 'https://github.com/tonlabs/ton-labs-block-json.git', tag = '0.7.19' }
 ton_executor = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-executor.git', tag = '1.15.74' }

--- a/ton_client/src/abi/encode_message.rs
+++ b/ton_client/src/abi/encode_message.rs
@@ -676,6 +676,13 @@ pub struct ParamsOfEncodeMessageBody {
     ///
     /// Default value is 0.
     pub processing_try_index: Option<u8>,
+
+    /// Destination address of the message
+    /// 
+    /// Since ABI version 2.3 destination address of external inbound message is used in message 
+    /// body signature calculation. Should be provided when signed external inbound message body is
+    /// created. Otherwise can be omitted.
+    pub address: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, ApiType, Default)]
@@ -717,6 +724,7 @@ pub async fn encode_message_body(
                 call.input.clone(),
                 params.is_internal,
                 None,
+                params.address,
             )
             .map_err(|err| Error::encode_run_message_failed(err, Some(&func)))?;
             (body, None)
@@ -730,6 +738,7 @@ pub async fn encode_message_body(
                     call.input,
                     true,
                     None,
+                    params.address,
                 ).map(|body| (body, None))
             } else {
                 ton_abi::prepare_function_call_for_sign(
@@ -737,6 +746,7 @@ pub async fn encode_message_body(
                     func.clone(),
                     call.header,
                     call.input,
+                    params.address,
                 ).map(|(body, data_to_sign)| (body, Some(data_to_sign)))
             }.map_err(|err| Error::encode_run_message_failed(err, Some(&func)))?
         }

--- a/ton_client/src/abi/tests.rs
+++ b/ton_client/src/abi/tests.rs
@@ -165,6 +165,7 @@ fn encode_v2() {
         is_internal: false,
         processing_try_index: run_params.processing_try_index,
         signer: run_params.signer,
+        address: Some(address.into()),
     };
     let extract_body = |message| {
         let unsigned_parsed: crate::boc::ResultOfParse = client

--- a/ton_client/src/debot/dengine.rs
+++ b/ton_client/src/debot/dengine.rs
@@ -280,6 +280,7 @@ impl DEngine {
             processing_try_index: None,
             is_internal: true,
             call_set: CallSet::some_with_function_and_input(func_name, params).unwrap(),
+            address: Some(self.addr.clone())
         };
         let body = encode_message_body(self.ton.clone(), msg_params).await?.body;
         let (_, body_cell) = deserialize_cell_from_base64(&body, "message body")?;

--- a/ton_client/src/debot/dengine.rs
+++ b/ton_client/src/debot/dengine.rs
@@ -280,7 +280,7 @@ impl DEngine {
             processing_try_index: None,
             is_internal: true,
             call_set: CallSet::some_with_function_and_input(func_name, params).unwrap(),
-            address: Some(self.addr.clone())
+            address: Some(self.addr.clone()),
         };
         let body = encode_message_body(self.ton.clone(), msg_params).await?.body;
         let (_, body_cell) = deserialize_cell_from_base64(&body, "message body")?;

--- a/ton_sdk/Cargo.toml
+++ b/ton_sdk/Cargo.toml
@@ -6,7 +6,7 @@ license = 'Apache-2.0'
 authors = [ 'TON Labs LTD <support@tonlabs.io>' ]
 
 [dependencies]
-ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', branch = "abi-v2_3" }
+ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', tag = '2.3.0' }
 ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.51' }
 ton_vm = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-vm.git', tag = '1.8.39' }
 ton_types = { git = 'https://github.com/tonlabs/ton-labs-types.git', tag = '1.11.2' }

--- a/ton_sdk/Cargo.toml
+++ b/ton_sdk/Cargo.toml
@@ -6,7 +6,7 @@ license = 'Apache-2.0'
 authors = [ 'TON Labs LTD <support@tonlabs.io>' ]
 
 [dependencies]
-ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', tag = '2.2.9' }
+ton_abi = { git = 'https://github.com/tonlabs/ton-labs-abi.git', branch = "abi-v2_3" }
 ton_block = { git = 'https://github.com/tonlabs/ton-labs-block.git', tag = '1.7.51' }
 ton_vm = { default-features = false, git = 'https://github.com/tonlabs/ton-labs-vm.git', tag = '1.8.39' }
 ton_types = { git = 'https://github.com/tonlabs/ton-labs-types.git', tag = '1.11.2' }

--- a/ton_sdk/src/contract.rs
+++ b/ton_sdk/src/contract.rs
@@ -294,6 +294,7 @@ impl Contract {
             params.input,
             false,
             key_pair,
+            Some(address.to_string()),
         )?;
 
         let msg = Self::create_ext_in_message(address.clone(), msg_body.into_cell()?.into())?;
@@ -325,6 +326,7 @@ impl Contract {
             params.input,
             true,
             None,
+            Some(address.to_string()),
         )?;
 
         Self::construct_int_message_with_body(
@@ -368,6 +370,7 @@ impl Contract {
             params.func,
             params.header,
             params.input,
+            Some(address.to_string()),
         )?;
 
         let msg = Self::create_ext_in_message(address, msg_body.into_cell()?.into())?;
@@ -396,6 +399,7 @@ impl Contract {
             params.input,
             false,
             key_pair,
+            Some(image.msg_address(workchain_id).to_string()),
         )?;
 
         let cell: SliceData = msg_body.into_cell()?.into();
@@ -466,6 +470,7 @@ impl Contract {
             params.func,
             params.header,
             params.input,
+            Some(image.msg_address(workchain_id).to_string()),
         )?;
 
         let cell: SliceData = msg_body.into_cell()?.into();
@@ -494,6 +499,7 @@ impl Contract {
             params.input,
             true,
             None,
+            Some(image.msg_address(workchain_id).to_string()),
         )?;
 
         let cell: SliceData = msg_body.into_cell()?.into();


### PR DESCRIPTION
- ABI specification v2.3 is supported
- parameter `address` is added to `abi.encode_message_body` function