### PR TITLE
1.37.0 auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.37.0] – 2022-07-18
+
+### New
+
+- client sends `config.network.access_key` as `Authorization: Basic ...` or `Authorization: Bearer ...` header. 
+
+
 ## [1.36.1] – 2022-07-18
 
 ### Improvement
 
-- Time synchorization check between device and server improved:  calculation of timediff with server is  moved from batched query to send_message function and therefore now query execution time does not affect this time diff. 
+- Time synchronization check between device and server improved:  calculation of time-diff 
+  with server is  moved from batched query to send_message function and therefore now query 
+  execution time does not affect this time diff. 
 
 
 ## [1.36.0] – 2022-07-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### New
 
 - client sends `config.network.access_key` as `Authorization: Basic ...` or `Authorization: Bearer ...` header. 
-
+- client accepts endpoints with `/graphql` suffixes specified in config.
 
 ## [1.36.1] – 2022-07-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "api_derive"
-version = "1.36.0"
+version = "1.36.1"
 dependencies = [
  "api_info",
  "quote",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "api_info"
-version = "1.36.0"
+version = "1.36.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "api_test"
-version = "1.36.0"
+version = "1.36.1"
 dependencies = [
  "api_derive",
  "api_info",
@@ -2339,8 +2339,8 @@ dependencies = [
 
 [[package]]
 name = "ton_abi"
-version = "2.3.0"
-source = "git+https://github.com/tonlabs/ton-labs-abi.git?tag=2.3.0#1d533869f5d00aa53d94137b83de2c8de41453ee"
+version = "2.3.1"
+source = "git+https://github.com/tonlabs/ton-labs-abi.git?tag=2.3.1#cb442bca8244a6bfd316c96c2fc0a99114ab32c3"
 dependencies = [
  "base64 0.10.1",
  "byteorder",
@@ -2355,7 +2355,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.8.2",
- "ton_block 1.7.53",
+ "ton_block",
  "ton_types",
 ]
 
@@ -2374,27 +2374,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "ton_block 1.8.0",
+ "ton_block",
  "ton_tl_codegen",
- "ton_types",
-]
-
-[[package]]
-name = "ton_block"
-version = "1.7.53"
-source = "git+https://github.com/tonlabs/ton-labs-block.git?tag=1.7.53#1e44539c3ac26c7ef4b7dd67dbeec07477410d02"
-dependencies = [
- "base64 0.13.0",
- "crc 3.0.0",
- "ed25519",
- "ed25519-dalek",
- "failure",
- "hex 0.4.3",
- "log",
- "num",
- "num-traits",
- "rand 0.7.3",
- "sha2 0.10.2",
  "ton_types",
 ]
 
@@ -2430,13 +2411,13 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "ton_api",
- "ton_block 1.8.0",
+ "ton_block",
  "ton_types",
 ]
 
 [[package]]
 name = "ton_client"
-version = "1.36.0"
+version = "1.36.1"
 dependencies = [
  "aes",
  "api_derive",
@@ -2486,7 +2467,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "ton_abi",
- "ton_block 1.8.0",
+ "ton_block",
  "ton_block_json",
  "ton_executor",
  "ton_sdk",
@@ -2507,14 +2488,14 @@ dependencies = [
  "failure",
  "lazy_static",
  "log",
- "ton_block 1.8.0",
+ "ton_block",
  "ton_types",
  "ton_vm",
 ]
 
 [[package]]
 name = "ton_sdk"
-version = "1.36.0"
+version = "1.36.1"
 dependencies = [
  "api_derive",
  "api_info",
@@ -2532,7 +2513,7 @@ dependencies = [
  "serde_json",
  "sha2 0.9.9",
  "ton_abi",
- "ton_block 1.8.0",
+ "ton_block",
  "ton_types",
  "ton_vm",
 ]
@@ -2587,13 +2568,13 @@ dependencies = [
  "num-traits",
  "rand 0.7.3",
  "sha2 0.9.9",
- "ton_block 1.8.0",
+ "ton_block",
  "ton_types",
 ]
 
 [[package]]
 name = "toncli"
-version = "1.36.0"
+version = "1.36.1"
 dependencies = [
  "api_info",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
 
 [[package]]
 name = "cc"
@@ -429,9 +429,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ccfd8c0ee4cce11e45b3fd6f9d5e69e0cc62912aa6a0cb1bf4617b0eba5a12f"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.5",
  "typenum",
@@ -648,9 +648,9 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -831,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "graphql-parser"
@@ -866,18 +866,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
 
 [[package]]
 name = "hermit-abi"
@@ -1064,7 +1058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1108,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1254,11 +1248,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84e6fe5655adc6ce00787cf7dcaf8dc4f998a0565d23eafc207a8b08ca3349a"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1697,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1786,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
@@ -1962,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
 dependencies = [
  "serde_derive",
 ]
@@ -1981,9 +1975,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2027,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec0091e1f5aa338283ce049bd9dfefd55e1f168ac233e85c1ffe0038fb48cbe"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap",
  "ryu",
@@ -2104,9 +2098,12 @@ checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
@@ -2260,9 +2257,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2676,9 +2673,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "unicode-normalization"
@@ -2811,9 +2808,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -2821,13 +2818,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -2836,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
+checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2848,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2858,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2871,15 +2868,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "web-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2970,9 +2967,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b578acffd8516a6c3f2a1bdefc1ec37e547bb4e0fb8b6b01a4cafc886b4442"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 dependencies = [
  "zeroize_derive",
 ]

--- a/ton_client/src/net/endpoint.rs
+++ b/ton_client/src/net/endpoint.rs
@@ -88,8 +88,11 @@ impl Endpoint {
             };
             format!("{}{}", protocol, base_url)
         };
-
-        format!("{}/graphql", base_url.trim_end_matches("/"))
+        if base_url.ends_with("/graphql") {
+            base_url
+        } else {
+            format!("{}/graphql", base_url)
+        }
     }
 
     async fn fetch_info_with_url(

--- a/ton_client/src/net/endpoint.rs
+++ b/ton_client/src/net/endpoint.rs
@@ -62,7 +62,7 @@ const HTTP_PROTOCOL: &str = "http://";
 const HTTPS_PROTOCOL: &str = "https://";
 
 impl Endpoint {
-    pub fn http_headers(access_key: Option<&String>) -> Vec<(String, String)> {
+    pub fn http_headers(config: &NetworkConfig) -> Vec<(String, String)> {
         let mut headers = vec![
             ("tonclient-core-version".to_string(), core_version()),
             (
@@ -70,8 +70,8 @@ impl Endpoint {
                 BOC_VERSION.to_owned(),
             ),
         ];
-        if let Some(access_key) = access_key {
-            headers.push(("accessKey".into(), access_key.clone()));
+        if let Some(auth) = config.get_auth_header() {
+            headers.push(auth);
         }
         headers
     }
@@ -97,11 +97,11 @@ impl Endpoint {
         query_url: &str,
         query: &str,
         timeout: u32,
-        access_key: Option<&String>,
+        config: &NetworkConfig,
     ) -> ClientResult<(Value, String, Option<String>)> {
         let mut headers = HashMap::new();
         headers.insert("content-type".to_owned(), "application/json".to_owned());
-        for (name, value) in Self::http_headers(access_key) {
+        for (name, value) in Self::http_headers(config) {
             headers.insert(name, value);
         }
         let response = client_env
@@ -130,7 +130,7 @@ impl Endpoint {
             &address,
             QUERY_INFO_VERSION_TIME,
             config.query_timeout,
-            config.access_key.as_ref(),
+            config,
         )
         .await?;
         let subscription_url = query_url
@@ -168,7 +168,7 @@ impl Endpoint {
                 &self.query_url,
                 query,
                 config.query_timeout,
-                config.access_key.as_ref(),
+                config,
             )
             .await?;
             self.apply_server_info(client_env, config, info_request_time, &info)?;

--- a/ton_client/src/net/server_link.rs
+++ b/ton_client/src/net/server_link.rs
@@ -547,7 +547,7 @@ impl ServerLink {
 
         let mut headers = HashMap::new();
         headers.insert("content-type".to_owned(), "application/json".to_owned());
-        for (name, value) in Endpoint::http_headers(self.config.access_key.as_ref()) {
+        for (name, value) in Endpoint::http_headers(&self.config) {
             headers.insert(name, value);
         }
 

--- a/ton_client/src/net/tests.rs
+++ b/ton_client/src/net/tests.rs
@@ -65,7 +65,7 @@ async fn endpoints_with_graphql_suffix() {
         .await
         .unwrap();
 
-    assert_eq!(endpoint.query_url, "http://localhost/graphql");
+    assert_eq!(endpoint.query_url, format!("{}/graphql", url));
 
     let client = TestClient::new_with_config(json!({
         "network": {
@@ -79,7 +79,7 @@ async fn endpoints_with_graphql_suffix() {
         .get_query_endpoint()
         .await
         .unwrap();
-    assert_eq!(endpoint.query_url, "http://localhost/graphql");
+    assert_eq!(endpoint.query_url, format!("{}/graphql", url));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/ton_client/src/net/tests.rs
+++ b/ton_client/src/net/tests.rs
@@ -44,6 +44,45 @@ async fn auth_header() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn endpoints_with_graphql_suffix() {
+    let url = TestClient::endpoints()[0].clone();
+    let url = if let Some(url) = url.strip_suffix("/graphql") {
+        url.to_string()
+    } else {
+        url
+    };
+
+    let client = TestClient::new_with_config(json!({
+        "network": {
+            "endpoints": vec![format!("{}/graphql", url)]
+        }
+    }));
+    let endpoint = client
+        .context()
+        .get_server_link()
+        .unwrap()
+        .get_query_endpoint()
+        .await
+        .unwrap();
+
+    assert_eq!(endpoint.query_url, "http://localhost/graphql");
+
+    let client = TestClient::new_with_config(json!({
+        "network": {
+            "endpoints": vec![url.clone()]
+        }
+    }));
+    let endpoint = client
+        .context()
+        .get_server_link()
+        .unwrap()
+        .get_query_endpoint()
+        .await
+        .unwrap();
+    assert_eq!(endpoint.query_url, "http://localhost/graphql");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn batch_query() {
     let client = TestClient::new();
 

--- a/ton_client/src/net/tests.rs
+++ b/ton_client/src/net/tests.rs
@@ -16,6 +16,34 @@ use std::sync::Arc;
 use std::vec;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn auth_header() {
+    let client = TestClient::new_with_config(json!({
+        "network": {
+            "access_key": "secret"
+        }
+    }));
+    assert_eq!(
+        Some((
+            "Authorization".to_string(),
+            "Basic OnNlY3JldA==".to_string()
+        )),
+        client.context().config.network.get_auth_header()
+    );
+    let jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    let client = TestClient::new_with_config(json!({
+        "network": {
+            "access_key": jwt
+        }
+    }));
+    assert_eq!(
+        Some(("Authorization".to_string(), format!("Bearer {}", jwt))),
+        client.context().config.network.get_auth_header()
+    );
+    let client = TestClient::new();
+    assert_eq!(None, client.context().config.network.get_auth_header());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn batch_query() {
     let client = TestClient::new();
 
@@ -1331,4 +1359,3 @@ async fn query_using_ws() {
 
     assert!(messages.result.len() > 0);
 }
-

--- a/ton_client/src/processing/send_message.rs
+++ b/ton_client/src/processing/send_message.rs
@@ -149,9 +149,9 @@ impl SendingMessage {
 
         let addresses = context.get_server_link()?.get_addresses_for_sending().await;
         let mut last_result = None::<ClientResult<String>>;
-        let succedeed_limit = context.config.network.sending_endpoint_count as usize;
+        let succeeded_limit = context.config.network.sending_endpoint_count as usize;
         let mut succeeded = Vec::new();
-        'sending: for selected_addresses in addresses.chunks(succedeed_limit) {
+        'sending: for selected_addresses in addresses.chunks(succeeded_limit) {
             let mut futures = vec![];
             for address in selected_addresses {
                 let context = context.clone();
@@ -163,7 +163,7 @@ impl SendingMessage {
             for result in futures::future::join_all(futures).await {
                 if let Ok(address) = &result {
                     succeeded.push(address.clone());
-                    if succeeded.len() >= succedeed_limit {
+                    if succeeded.len() >= succeeded_limit {
                         break 'sending;
                     }
                 }


### PR DESCRIPTION
### New

- client sends `config.network.access_key` as `Authorization: Basic ...` or `Authorization: Bearer ...` header. 
- client accepts endpoints with `/graphql` suffixes specified in config.
