### PR TITLE
NEW: `create_crypto_box` optimisation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,24 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [1.37.2] – 2022-08-10
 
-### New
+### Improvement
 
 - `create_crypto_box` optimisation.
-  When user creates crypto box, SDK encrypts provided secret information using provided 
+  When a user creates a crypto box, library encrypts provided secret information using provided 
   password and salt.
-  When SDK encrypts secret, it calculates encryption key from password and salt 
+  When library encrypts the secret, it calculates encryption key from password and salt 
   using `scrypt` function which takes a lot of CPU time (about 1 second).
-  So when the user creates many crypto boxes using same password and salt, 
-  it is required a lot of time (about 12 seconds for 10 crypto boxes).
-  With an optimisations introduced in this version the SDK stores 
+  So when a user creates many crypto boxes using the same password and salt, 
+  it takes a lot of time (about 12 seconds for 10 crypto boxes).
+  With the optimisations introduced in this version the library stores the 
   pair (password+salt => encryption key) in internal cache for approximately 2 seconds.
-  So when the user creates many crypto boxes at a time using the same password and salt, 
-  SDK uses cached information to skip heavy calculations. As a result there are only 
-  a single second required to create 10 crypto boxes.  
+  So when a user creates many crypto boxes at a time using the same password and salt, 
+  library uses cached information to skip heavy calculations. As a result now it takes only 
+  a second to create 10 crypto boxes.  
 
 ### Fixed
 
-- Some enum types wasn't properly presented in api.json (some types that uses serde(content="value"))
+- Some enum types ware not properly presented in api.json (some types that use serde(content="value"))
 
 ## [1.37.1] – 2022-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,17 @@ All notable changes to this project will be documented in this file.
 ### New
 
 - `create_crypto_box` optimisation.
-  When user creates crypto box, SDK encrypts provided secret information using provided password 
-  and salt.
-  When SDK encrypts secret, it derives encryption key from password and salt using `scrypt` 
-  function which takes a lot of CPU time (about 1 second).
-  So when the user creates many crypto boxes using same password and salt, it is required a lot 
-  of time (about 12 seconds for 10 crypto boxes).
-  With optimisations introduced in this version the SDK caches mapping (password+salt => encryption key) 
-  for approximately 2 seconds.
-  So when the user creates many crypto boxes using same password and salt, it is required only 
-  a 1.2 seconds for 10 crypto boxes.
-  
+  When user creates crypto box, SDK encrypts provided secret information using provided 
+  password and salt.
+  When SDK encrypts secret, it calculates encryption key from password and salt 
+  using `scrypt` function which takes a lot of CPU time (about 1 second).
+  So when the user creates many crypto boxes using same password and salt, 
+  it is required a lot of time (about 12 seconds for 10 crypto boxes).
+  With an optimisations introduced in this version the SDK stores 
+  pair (password+salt => encryption key) in internal cache for approximately 2 seconds.
+  So when the user creates many crypto boxes at a time using the same password and salt, 
+  SDK uses cached information to skip heavy calculations. As a result there are only 
+  a single second required to create 10 crypto boxes.  
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Some enum types ware not properly presented in api.json (some types that use serde(content="value"))
+- Some enum types were not properly presented in api.json (some types that use serde(content="value"))
 
 ## [1.37.1] – 2022-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [1.37.2] – 2022-08-10
 
+### New
+
+- `create_crypto_box` optimisation.
+  When user creates crypto box, SDK encrypts provided secret information using provided password 
+  and salt.
+  When SDK encrypts secret, it derives encryption key from password and salt using `scrypt` 
+  function which takes a lot of CPU time (about 1 second).
+  So when the user creates many crypto boxes using same password and salt, it is required a lot 
+  of time (about 12 seconds for 10 crypto boxes).
+  With optimisations introduced in this version the SDK caches mapping (password+salt => encryption key) 
+  for approximately 2 seconds.
+  So when the user creates many crypto boxes using same password and salt, it is required only 
+  a 1.2 seconds for 10 crypto boxes.
+  
+
 ### Fixed
 
 - Some enum types wasn't properly presented in api.json (some types that uses serde(content="value"))

--- a/ton_client/src/crypto/boxes/crypto_box/derived_keys.rs
+++ b/ton_client/src/crypto/boxes/crypto_box/derived_keys.rs
@@ -1,0 +1,141 @@
+use crate::client::ClientEnv;
+use crate::crypto;
+use crate::crypto::internal::SecretBuf;
+use crate::error::ClientResult;
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+struct SecretHash(u64);
+
+impl Drop for SecretHash {
+    fn drop(&mut self) {
+        self.0 = 0;
+    }
+}
+
+struct DerivedKey {
+    hash: SecretHash,
+    ttl_ms: u64,
+    expired_at: u64,
+    key: SecretBuf,
+}
+
+impl DerivedKey {
+    fn calc_hash(password: &[u8], salt: &str) -> SecretHash {
+        let crc = crc::Crc::<u64>::new(&crc::CRC_64_ECMA_182);
+        let mut digest = crc.digest();
+        digest.update(password);
+        digest.update(salt.as_bytes());
+        SecretHash(digest.finalize())
+    }
+
+    fn calc_key(password: &[u8], salt: &str) -> ClientResult<SecretBuf> {
+        let scrypt_params = scrypt::Params::new(14, 8, 1).expect("Scrypt params setup failed");
+        let mut key = SecretBuf(vec![0; 32]);
+        scrypt::scrypt(password, salt.as_bytes(), &scrypt_params, &mut key.0)
+            .map_err(|err| crypto::Error::scrypt_failed(err))?;
+        Ok(key)
+    }
+}
+
+struct DerivedKeysCache {
+    keys: Vec<DerivedKey>,
+    env: Arc<ClientEnv>,
+}
+
+impl DerivedKeysCache {
+    fn touch(&mut self, hash: &SecretHash) -> Option<&SecretBuf> {
+        for key in &mut self.keys {
+            if key.hash.0 == hash.0 {
+                println!("use cached key");
+                key.expired_at = self.env.now_ms() + key.ttl_ms;
+                return Some(&key.key);
+            }
+        }
+        None
+    }
+
+    // Ensure that key is present in cache and returns `true` if the clean timer must be started
+    fn put_and_check_start_timer(
+        &mut self,
+        hash: &SecretHash,
+        key: &SecretBuf,
+        calculation_time: u64,
+    ) -> bool {
+        if self.touch(hash).is_some() {
+            return false;
+        }
+        let ttl_ms = calculation_time * 2;
+        self.keys.push(DerivedKey {
+            hash: SecretHash(hash.0),
+            key: key.clone(),
+            ttl_ms,
+            expired_at: self.env.now_ms() + ttl_ms,
+        });
+        println!("put key to cache with ttl {}", ttl_ms);
+        self.keys.len() == 1
+    }
+
+    fn clean_and_check_stop_timer(&mut self) -> bool {
+        let now = self.env.now_ms();
+        for i in (0..self.keys.len()).rev() {
+            if self.keys[i].expired_at <= now {
+                println!("remove expired key");
+                self.keys.remove(i);
+            }
+        }
+        self.keys.is_empty()
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct DerivedKeys {
+    cache: Arc<RwLock<DerivedKeysCache>>,
+}
+
+impl DerivedKeys {
+    pub(crate) fn new(env: Arc<ClientEnv>) -> Self {
+        Self {
+            cache: Arc::new(RwLock::new(DerivedKeysCache {
+                keys: Vec::new(),
+                env,
+            })),
+        }
+    }
+
+    pub(crate) fn derive(&self, password: &[u8], salt: &str) -> ClientResult<SecretBuf> {
+        let hash = DerivedKey::calc_hash(password, salt);
+        if let Some(existing) = { self.write_cache().touch(&hash).map(|x| x.clone()) } {
+            return Ok(existing);
+        }
+        let calculation_start = { self.read_cache().env.now_ms() };
+        let key = DerivedKey::calc_key(password, salt)?;
+        let calculation_time = { self.read_cache().env.now_ms() - calculation_start };
+        let start_timer = {
+            self.write_cache()
+                .put_and_check_start_timer(&hash, &key, calculation_time)
+        };
+        if start_timer {
+            let keys = self.clone();
+            let env = { self.read_cache().env.clone() };
+            let inner_env = env.clone();
+            env.spawn(async move {
+                let mut stop_timer = false;
+                println!("start clean timer");
+                while !stop_timer {
+                    let _ = inner_env.set_timer(1000u64).await;
+                    stop_timer = keys.write_cache().clean_and_check_stop_timer();
+                }
+                println!("stop clean timer");
+            });
+        }
+        Ok(key)
+    }
+
+    fn read_cache(&self) -> RwLockReadGuard<DerivedKeysCache> {
+        self.cache.read().unwrap()
+    }
+
+    fn write_cache(&self) -> RwLockWriteGuard<DerivedKeysCache> {
+        self.cache.write().unwrap()
+    }
+}

--- a/ton_client/src/crypto/boxes/crypto_box/mod.rs
+++ b/ton_client/src/crypto/boxes/crypto_box/mod.rs
@@ -6,22 +6,25 @@ use lockfree::map::ReadGuard;
 use tokio::sync::RwLock;
 use zeroize::Zeroize;
 
-use crate::ClientContext;
-use crate::crypto::internal::{SecretString, SecretBuf};
-use crate::crypto::{
-    CryptoConfig, EncryptionBox, EncryptionBoxInfo, Error, register_encryption_box,
-    register_signing_box, RegisteredEncryptionBox, RegisteredSigningBox, SigningBox,
-};
 use crate::crypto::boxes::crypto_box::encryption::{decrypt_secret, encrypt_secret};
 use crate::crypto::boxes::encryption_box::chacha20::ChaCha20EncryptionBox;
 use crate::crypto::boxes::encryption_box::nacl_box::NaclEncryptionBox;
 use crate::crypto::boxes::encryption_box::nacl_secret_box::NaclSecretEncryptionBox;
 use crate::crypto::boxes::signing_box::KeysSigningBox;
+use crate::crypto::internal::{SecretBuf, SecretString};
 use crate::crypto::mnemonic::mnemonics;
+use crate::crypto::{
+    register_encryption_box, register_signing_box, CryptoConfig, EncryptionBox, EncryptionBoxInfo,
+    Error, RegisteredEncryptionBox, RegisteredSigningBox, SigningBox,
+};
 use crate::encoding::{base64_decode, hex_decode};
 use crate::error::ClientResult;
+use crate::ClientContext;
 
 mod encryption;
+mod derived_keys;
+
+pub(crate) use derived_keys::DerivedKeys;
 
 type PasswordProvider = Arc<dyn AppPasswordProvider + Send + Sync + 'static>;
 
@@ -81,7 +84,7 @@ pub(crate) struct CryptoBox {
 
 /// Crypto Box Secret.
 #[derive(Serialize, Deserialize, Clone, Debug, ApiType, PartialEq, Zeroize, ZeroizeOnDrop)]
-#[serde(tag="type")]
+#[serde(tag = "type")]
 pub enum CryptoBoxSecret {
     /// Creates Crypto Box from a random seed phrase.
     /// This option can be used if a developer doesn't want the seed phrase to leave the core
@@ -91,10 +94,7 @@ pub enum CryptoBoxSecret {
     /// should use `EncryptedSecret` type instead.
     ///
     /// Get `encrypted_secret` with `get_crypto_box_info` function and store it on your side.
-    RandomSeedPhrase {
-        dictionary: u8,
-        wordcount: u8,
-    },
+    RandomSeedPhrase { dictionary: u8, wordcount: u8 },
 
     /// Restores crypto box instance from an existing seed phrase.
     /// This type should be used when Crypto Box is initialized from a seed phrase, entered by a user.
@@ -135,7 +135,9 @@ impl Default for CryptoBoxSecret {
     }
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, Debug, ApiType, PartialEq, Zeroize, ZeroizeOnDrop)]
+#[derive(
+    Serialize, Deserialize, Default, Clone, Debug, ApiType, PartialEq, Zeroize, ZeroizeOnDrop,
+)]
 pub struct ParamsOfCreateCryptoBox {
     /// Salt used for secret encryption.
     /// For example, a mobile device can use device ID as salt.
@@ -162,7 +164,10 @@ pub async fn create_crypto_box(
     password_provider: PasswordProvider,
 ) -> ClientResult<RegisteredCryptoBox> {
     let encrypted_secret = match &params.secret {
-        CryptoBoxSecret::RandomSeedPhrase { dictionary, wordcount } => {
+        CryptoBoxSecret::RandomSeedPhrase {
+            dictionary,
+            wordcount,
+        } => {
             let config = CryptoConfig::default();
             let phrase = {
                 let mnemonics = mnemonics(&config, Some(*dictionary), Some(*wordcount))?;
@@ -173,14 +178,21 @@ pub async fn create_crypto_box(
                 }
             };
             encrypt_secret(
+                context.clone(),
                 &phrase,
                 &password_provider,
                 &params.secret_encryption_salt,
-            ).await?
-        },
+            )
+            .await?
+        }
 
-        CryptoBoxSecret::PredefinedSeedPhrase { phrase, dictionary, wordcount } => {
+        CryptoBoxSecret::PredefinedSeedPhrase {
+            phrase,
+            dictionary,
+            wordcount,
+        } => {
             encrypt_secret(
+                context.clone(),
                 &SecretInternal::SeedPhrase {
                     phrase: SecretString(phrase.clone()),
                     dictionary: *dictionary,
@@ -188,11 +200,13 @@ pub async fn create_crypto_box(
                 },
                 &password_provider,
                 &params.secret_encryption_salt,
-            ).await?
-        },
+            )
+            .await?
+        }
 
-        CryptoBoxSecret::EncryptedSecret { encrypted_secret } =>
-            SecretBuf(base64_decode(&encrypted_secret)?),
+        CryptoBoxSecret::EncryptedSecret { encrypted_secret } => {
+            SecretBuf(base64_decode(&encrypted_secret)?)
+        }
     };
 
     let crypto_box = CryptoBox {
@@ -203,11 +217,13 @@ pub async fn create_crypto_box(
     let id = context.get_next_id();
     assert!(context.boxes.crypto_boxes.insert(id, crypto_box).is_none());
 
-    Ok(RegisteredCryptoBox { handle: CryptoBoxHandle(id) })
+    Ok(RegisteredCryptoBox {
+        handle: CryptoBoxHandle(id),
+    })
 }
 
 /// Removes Crypto Box.
-/// Clears all secret data. 
+/// Clears all secret data.
 #[api_function]
 pub async fn remove_crypto_box(
     context: Arc<ClientContext>,
@@ -217,7 +233,9 @@ pub async fn remove_crypto_box(
     Ok(())
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, ApiType, Default, PartialEq, Zeroize, ZeroizeOnDrop)]
+#[derive(
+    Serialize, Deserialize, Clone, Debug, ApiType, Default, PartialEq, Zeroize, ZeroizeOnDrop,
+)]
 pub struct ResultOfGetCryptoBoxSeedPhrase {
     pub phrase: String,
     pub dictionary: u8,
@@ -232,17 +250,27 @@ pub async fn get_crypto_box_seed_phrase(
     context: Arc<ClientContext>,
     params: RegisteredCryptoBox,
 ) -> ClientResult<ResultOfGetCryptoBoxSeedPhrase> {
-    let SecretInternal::SeedPhrase { phrase, dictionary, wordcount } = {
+    let SecretInternal::SeedPhrase {
+        phrase,
+        dictionary,
+        wordcount,
+    } = {
         let guard = get_crypto_box(&context, &params.handle)?;
         let crypto_box = guard.val();
         decrypt_secret(
+            context.clone(),
             &crypto_box.encrypted_secret.0,
             &crypto_box.password_provider,
             &crypto_box.secret_encryption_salt.0,
-        ).await?
+        )
+        .await?
     };
 
-    Ok(ResultOfGetCryptoBoxSeedPhrase { phrase: phrase.0.clone(), dictionary, wordcount })
+    Ok(ResultOfGetCryptoBoxSeedPhrase {
+        phrase: phrase.0.clone(),
+        dictionary,
+        wordcount,
+    })
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, ApiType, Default, PartialEq)]
@@ -253,21 +281,30 @@ pub struct ResultOfGetCryptoBoxInfo {
 
 /// Get Crypto Box Info.
 /// Used to get `encrypted_secret` that should be used
-/// for all the cryptobox initializations except the first one. 
+/// for all the cryptobox initializations except the first one.
 #[api_function]
 pub async fn get_crypto_box_info(
     context: Arc<ClientContext>,
     params: RegisteredCryptoBox,
 ) -> ClientResult<ResultOfGetCryptoBoxInfo> {
     Ok(ResultOfGetCryptoBoxInfo {
-        encrypted_secret: base64::encode(&get_crypto_box(&context, &params.handle)?.val().encrypted_secret.0),
+        encrypted_secret: base64::encode(
+            &get_crypto_box(&context, &params.handle)?
+                .val()
+                .encrypted_secret
+                .0,
+        ),
     })
 }
 
-fn get_crypto_box<'context>(context: &'context Arc<ClientContext>, handle: &CryptoBoxHandle)
-    -> ClientResult<ReadGuard<'context, u32, CryptoBox>>
-{
-    context.boxes.crypto_boxes.get(&handle.0)
+fn get_crypto_box<'context>(
+    context: &'context Arc<ClientContext>,
+    handle: &CryptoBoxHandle,
+) -> ClientResult<ReadGuard<'context, u32, CryptoBox>> {
+    context
+        .boxes
+        .crypto_boxes
+        .get(&handle.0)
         .ok_or_else(|| Error::crypto_box_not_registered(handle.0))
 }
 
@@ -304,8 +341,9 @@ pub async fn get_signing_box_from_crypto_box(
                 secret_lifetime: params.secret_lifetime,
             },
             internal_box: Default::default(),
-        }
-    ).await
+        },
+    )
+    .await
 }
 
 struct BoxFromCryptoBoxLifeCycleManager<T> {
@@ -322,7 +360,7 @@ impl<T: Send + Sync + 'static> BoxFromCryptoBoxLifeCycleManager<T> {
     ) -> ClientResult<Ret>
     where
         Cb: Fn(Arc<T>) -> Fut,
-        Fut: Future<Output=ClientResult<Ret>>,
+        Fut: Future<Output = ClientResult<Ret>>,
     {
         if let Some(internal_box) = self.internal_box.read().await.as_ref() {
             return callback(Arc::clone(internal_box)).await;
@@ -334,10 +372,16 @@ impl<T: Send + Sync + 'static> BoxFromCryptoBoxLifeCycleManager<T> {
 
         let seed_phrase = get_crypto_box_seed_phrase(
             Arc::clone(&context),
-            RegisteredCryptoBox { handle: CryptoBoxHandle(self.params.handle) },
-        ).await?;
+            RegisteredCryptoBox {
+                handle: CryptoBoxHandle(self.params.handle),
+            },
+        )
+        .await?;
 
-        let hdpath = self.params.hdpath.as_ref()
+        let hdpath = self
+            .params
+            .hdpath
+            .as_ref()
             .unwrap_or(&context.config.crypto.hdkey_derivation_path);
 
         let keypair = {
@@ -347,13 +391,20 @@ impl<T: Send + Sync + 'static> BoxFromCryptoBoxLifeCycleManager<T> {
                 Some(seed_phrase.wordcount),
             )?;
 
-            mnemonic.derive_ed25519_keys_from_phrase(&context.config.crypto, &seed_phrase.phrase, hdpath)
-                .map::<ClientResult<Keypair>, _>(|keypair| Ok(Keypair {
-                    public: PublicKey::from_bytes(&hex_decode(&keypair.public)?)
-                        .map_err(|err| Error::invalid_public_key(err, &keypair.public))?,
-                    secret: SecretKey::from_bytes(&hex_decode(&keypair.secret)?)
-                        .map_err(|err| Error::invalid_secret_key(err, &keypair.secret))?,
-                }))??
+            mnemonic
+                .derive_ed25519_keys_from_phrase(
+                    &context.config.crypto,
+                    &seed_phrase.phrase,
+                    hdpath,
+                )
+                .map::<ClientResult<Keypair>, _>(|keypair| {
+                    Ok(Keypair {
+                        public: PublicKey::from_bytes(&hex_decode(&keypair.public)?)
+                            .map_err(|err| Error::invalid_public_key(err, &keypair.public))?,
+                        secret: SecretKey::from_bytes(&hex_decode(&keypair.secret)?)
+                            .map_err(|err| Error::invalid_secret_key(err, &keypair.secret))?,
+                    })
+                })??
         };
 
         let lifetime = self.params.secret_lifetime.unwrap_or(0) as u64;
@@ -385,12 +436,11 @@ impl SigningBox for BoxFromCryptoBoxLifeCycleManager<KeysSigningBox> {
             Arc::clone(&context),
             move |signing_box| {
                 let context = Arc::clone(&context);
-                async move {
-                    signing_box.get_public_key(Arc::clone(&context)).await
-                }
+                async move { signing_box.get_public_key(Arc::clone(&context)).await }
             },
             |key_pair| Ok(KeysSigningBox::new(key_pair)),
-        ).await
+        )
+        .await
     }
 
     async fn sign(&self, context: Arc<ClientContext>, unsigned: &[u8]) -> ClientResult<Vec<u8>> {
@@ -398,12 +448,11 @@ impl SigningBox for BoxFromCryptoBoxLifeCycleManager<KeysSigningBox> {
             Arc::clone(&context),
             move |signing_box| {
                 let context = Arc::clone(&context);
-                async move {
-                    signing_box.sign(Arc::clone(&context), unsigned).await
-                }
+                async move { signing_box.sign(Arc::clone(&context), unsigned).await }
             },
             |key_pair| Ok(KeysSigningBox::new(key_pair)),
-        ).await
+        )
+        .await
     }
 
     async fn drop_secret(&self, crypto_box_handle: CryptoBoxHandle) {
@@ -501,10 +550,10 @@ pub struct ParamsOfGetEncryptionBoxFromCryptoBox {
 /// Gets Encryption Box from Crypto Box.
 ///
 /// Derives encryption keypair from cryptobox secret and hdpath and
-/// stores it in cache for `secret_lifetime` 
+/// stores it in cache for `secret_lifetime`
 /// or until explicitly cleared by `clear_crypto_box_secret_cache` method.
 /// If `secret_lifetime` is not specified - overwrites encryption secret with zeroes immediately after
-/// encryption operation. 
+/// encryption operation.
 #[api_function]
 pub async fn get_encryption_box_from_crypto_box(
     context: Arc<ClientContext>,
@@ -538,23 +587,22 @@ impl EncryptionBoxFromCryptoBox {
     fn factory(&self, key_pair: Keypair) -> ClientResult<Box<dyn EncryptionBox + 'static>> {
         let secret = SecretString(hex::encode(key_pair.secret));
         Ok(match &self.algorithm {
-            BoxEncryptionAlgorithm::ChaCha20(params) =>
-                Box::new(ChaCha20EncryptionBox::new(
-                    params.to_encryption_box_params(secret),
-                    self.manager.params.hdpath.clone(),
-                )?),
+            BoxEncryptionAlgorithm::ChaCha20(params) => Box::new(ChaCha20EncryptionBox::new(
+                params.to_encryption_box_params(secret),
+                self.manager.params.hdpath.clone(),
+            )?),
 
-            BoxEncryptionAlgorithm::NaclBox(params) =>
-                Box::new(NaclEncryptionBox::new(
-                    params.to_encryption_box_params(secret),
-                    self.manager.params.hdpath.clone(),
-                )),
+            BoxEncryptionAlgorithm::NaclBox(params) => Box::new(NaclEncryptionBox::new(
+                params.to_encryption_box_params(secret),
+                self.manager.params.hdpath.clone(),
+            )),
 
-            BoxEncryptionAlgorithm::NaclSecretBox(params) =>
+            BoxEncryptionAlgorithm::NaclSecretBox(params) => {
                 Box::new(NaclSecretEncryptionBox::new(
                     params.to_encryption_box_params(secret),
                     self.manager.params.hdpath.clone(),
-                )),
+                ))
+            }
         })
     }
 }
@@ -562,42 +610,42 @@ impl EncryptionBoxFromCryptoBox {
 #[async_trait::async_trait]
 impl EncryptionBox for EncryptionBoxFromCryptoBox {
     async fn get_info(&self, context: Arc<ClientContext>) -> ClientResult<EncryptionBoxInfo> {
-        self.manager.with_internal_box(
-            Arc::clone(&context),
-            move |encryption_box| {
-                let context = Arc::clone(&context);
-                async move {
-                    encryption_box.get_info(Arc::clone(&context)).await
-                }
-            },
-            |key_pair| self.factory(key_pair),
-        ).await
+        self.manager
+            .with_internal_box(
+                Arc::clone(&context),
+                move |encryption_box| {
+                    let context = Arc::clone(&context);
+                    async move { encryption_box.get_info(Arc::clone(&context)).await }
+                },
+                |key_pair| self.factory(key_pair),
+            )
+            .await
     }
 
     async fn encrypt(&self, context: Arc<ClientContext>, data: &String) -> ClientResult<String> {
-        self.manager.with_internal_box(
-            Arc::clone(&context),
-            move |encryption_box| {
-                let context = Arc::clone(&context);
-                async move {
-                    encryption_box.encrypt(Arc::clone(&context), data).await
-                }
-            },
-            |key_pair| self.factory(key_pair),
-        ).await
+        self.manager
+            .with_internal_box(
+                Arc::clone(&context),
+                move |encryption_box| {
+                    let context = Arc::clone(&context);
+                    async move { encryption_box.encrypt(Arc::clone(&context), data).await }
+                },
+                |key_pair| self.factory(key_pair),
+            )
+            .await
     }
 
     async fn decrypt(&self, context: Arc<ClientContext>, data: &String) -> ClientResult<String> {
-        self.manager.with_internal_box(
-            Arc::clone(&context),
-            move |encryption_box| {
-                let context = Arc::clone(&context);
-                async move {
-                    encryption_box.decrypt(Arc::clone(&context), data).await
-                }
-            },
-            |key_pair| self.factory(key_pair),
-        ).await
+        self.manager
+            .with_internal_box(
+                Arc::clone(&context),
+                move |encryption_box| {
+                    let context = Arc::clone(&context);
+                    async move { encryption_box.decrypt(Arc::clone(&context), data).await }
+                },
+                |key_pair| self.factory(key_pair),
+            )
+            .await
     }
 
     async fn drop_secret(&self, crypto_box_handle: CryptoBoxHandle) {
@@ -607,7 +655,7 @@ impl EncryptionBox for EncryptionBoxFromCryptoBox {
     }
 }
 
-/// Removes cached secrets (overwrites with zeroes) from all signing and encryption boxes, 
+/// Removes cached secrets (overwrites with zeroes) from all signing and encryption boxes,
 /// derived from crypto box.
 #[api_function]
 pub async fn clear_crypto_box_secret_cache(

--- a/ton_client/src/crypto/tests.rs
+++ b/ton_client/src/crypto/tests.rs
@@ -1,6 +1,12 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use super::*;
 use crate::client::ParamsOfAppRequest;
+use crate::crypto::boxes::crypto_box::{
+    BoxEncryptionAlgorithm, ChaCha20ParamsCB, CryptoBoxSecret, ParamsOfCreateCryptoBox,
+    ParamsOfGetEncryptionBoxFromCryptoBox, ParamsOfGetSigningBoxFromCryptoBox, RegisteredCryptoBox,
+    ResultOfGetCryptoBoxInfo, ResultOfGetCryptoBoxSeedPhrase,
+};
+use crate::crypto::boxes::encryption_box::nacl_box::NaclBoxParamsEB;
+use crate::crypto::boxes::encryption_box::nacl_secret_box::NaclSecretBoxParamsEB;
 use crate::crypto::boxes::encryption_box::ParamsOfCreateEncryptionBox;
 use crate::crypto::encscrypt::{ParamsOfScrypt, ResultOfScrypt};
 use crate::crypto::hash::{ParamsOfHash, ResultOfHash};
@@ -11,8 +17,9 @@ use crate::crypto::hdkey::{
     ResultOfHDKeyXPrvFromMnemonic,
 };
 use crate::crypto::keys::{
-    KeyPair, ParamsOfConvertPublicKeyToTonSafeFormat, ParamsOfSign, ParamsOfVerifySignature,
-    ResultOfConvertPublicKeyToTonSafeFormat, ResultOfSign, ResultOfVerifySignature, strip_secret
+    strip_secret, KeyPair, ParamsOfConvertPublicKeyToTonSafeFormat, ParamsOfSign,
+    ParamsOfVerifySignature, ResultOfConvertPublicKeyToTonSafeFormat, ResultOfSign,
+    ResultOfVerifySignature,
 };
 use crate::crypto::math::{
     ParamsOfFactorize, ParamsOfGenerateRandomBytes, ParamsOfModularPower, ParamsOfTonCrc16,
@@ -30,19 +37,13 @@ use crate::crypto::nacl::{
     ResultOfNaclSignDetached, ResultOfNaclSignOpen,
 };
 use crate::crypto::{ParamsOfChaCha20, ResultOfChaCha20};
-use crate::crypto::boxes::crypto_box::{
-    BoxEncryptionAlgorithm, ChaCha20ParamsCB, CryptoBoxSecret, ParamsOfCreateCryptoBox, 
-    ParamsOfGetEncryptionBoxFromCryptoBox, ParamsOfGetSigningBoxFromCryptoBox, RegisteredCryptoBox, 
-    ResultOfGetCryptoBoxInfo, ResultOfGetCryptoBoxSeedPhrase,
-};
-use crate::crypto::boxes::encryption_box::nacl_box::NaclBoxParamsEB;
-use crate::crypto::boxes::encryption_box::nacl_secret_box::NaclSecretBoxParamsEB;
 use crate::json_interface::crypto::{
     ParamsOfAppPasswordProvider, ParamsOfAppSigningBox, ResultOfAppPasswordProvider,
     ResultOfAppSigningBox,
 };
 use crate::tests::TestClient;
-use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 fn base64_from_hex(hex: &str) -> String {
     base64::encode(&hex::decode(hex).unwrap())
@@ -306,18 +307,28 @@ fn nacl() {
     }).unwrap();
     assert_eq!(result.signature, "fb0cfe40eea5d6c960652e6ceb904da8a72ee2fcf6e05089cf835203179ff65bb48c57ecf31dcfcd26510bea67e64f3e6898b7c58300dc14338254268cade103");
     let signature = result.signature;
-    let result: ResultOfNaclSignDetachedVerify = client.request("crypto.nacl_sign_detached_verify", ParamsOfNaclSignDetachedVerify {
-        unsigned: base64::encode("Test Message"),
-        signature: signature.clone(),
-        public: "1869b7ef29d58026217e9cf163cbfbd0de889bdf1bf4daebf5433a312f5b8d6e".into(),
-    }).unwrap();
+    let result: ResultOfNaclSignDetachedVerify = client
+        .request(
+            "crypto.nacl_sign_detached_verify",
+            ParamsOfNaclSignDetachedVerify {
+                unsigned: base64::encode("Test Message"),
+                signature: signature.clone(),
+                public: "1869b7ef29d58026217e9cf163cbfbd0de889bdf1bf4daebf5433a312f5b8d6e".into(),
+            },
+        )
+        .unwrap();
     assert_eq!(result.succeeded, true);
 
-    let result: ResultOfNaclSignDetachedVerify = client.request("crypto.nacl_sign_detached_verify", ParamsOfNaclSignDetachedVerify {
-        unsigned: base64::encode("Test Message 1"),
-        signature: signature.clone(),
-        public: "1869b7ef29d58026217e9cf163cbfbd0de889bdf1bf4daebf5433a312f5b8d6e".into(),
-    }).unwrap();
+    let result: ResultOfNaclSignDetachedVerify = client
+        .request(
+            "crypto.nacl_sign_detached_verify",
+            ParamsOfNaclSignDetachedVerify {
+                unsigned: base64::encode("Test Message 1"),
+                signature: signature.clone(),
+                public: "1869b7ef29d58026217e9cf163cbfbd0de889bdf1bf4daebf5433a312f5b8d6e".into(),
+            },
+        )
+        .unwrap();
     assert_eq!(result.succeeded, false);
 
     // Box
@@ -764,10 +775,7 @@ async fn test_signing_box() {
     let keys = client.generate_sign_keys();
 
     let keys_box_handle = client
-        .request_async::<_, RegisteredSigningBox>(
-            "crypto.get_signing_box",
-            keys.clone(),
-        )
+        .request_async::<_, RegisteredSigningBox>("crypto.get_signing_box", keys.clone())
         .await
         .unwrap()
         .handle
@@ -783,14 +791,20 @@ async fn test_signing_box() {
                         .request_async(
                             "crypto.signing_box_get_public_key",
                             RegisteredSigningBox {
-                                handle: keys_box_handle.into()
+                                handle: keys_box_handle.into(),
                             },
-                        ).await.unwrap();
-                    client.resolve_app_request(
-                        request.app_request_id,
-                        ResultOfAppSigningBox::GetPublicKey { public_key: result.pubkey }
-                    ).await;
-                },
+                        )
+                        .await
+                        .unwrap();
+                    client
+                        .resolve_app_request(
+                            request.app_request_id,
+                            ResultOfAppSigningBox::GetPublicKey {
+                                public_key: result.pubkey,
+                            },
+                        )
+                        .await;
+                }
                 ParamsOfAppSigningBox::Sign { unsigned } => {
                     let result: ResultOfSigningBoxSign = client
                         .request_async(
@@ -799,23 +813,27 @@ async fn test_signing_box() {
                                 signing_box: keys_box_handle.into(),
                                 unsigned,
                             },
-                        ).await.unwrap();
-                    client.resolve_app_request(
-                        request.app_request_id,
-                        ResultOfAppSigningBox::Sign { signature: result.signature }
-                    ).await;
+                        )
+                        .await
+                        .unwrap();
+                    client
+                        .resolve_app_request(
+                            request.app_request_id,
+                            ResultOfAppSigningBox::Sign {
+                                signature: result.signature,
+                            },
+                        )
+                        .await;
                 }
             }
         });
         futures::future::ready(())
     };
 
-    let external_box: RegisteredSigningBox = client.request_async_callback(
-        "crypto.register_signing_box",
-        (),
-        callback
-    ).await.unwrap();
-
+    let external_box: RegisteredSigningBox = client
+        .request_async_callback("crypto.register_signing_box", (), callback)
+        .await
+        .unwrap();
 
     let box_pubkey: ResultOfSigningBoxGetPublicKey = client
         .request_async(
@@ -823,7 +841,9 @@ async fn test_signing_box() {
             RegisteredSigningBox {
                 handle: external_box.handle.clone(),
             },
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
     assert_eq!(box_pubkey.pubkey, keys.public);
 
@@ -835,16 +855,13 @@ async fn test_signing_box() {
                 signing_box: external_box.handle.clone(),
                 unsigned: unsigned.clone(),
             },
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
     let keys_sign: ResultOfSign = client
-        .request(
-            "crypto.sign",
-            ParamsOfSign {
-                unsigned,
-                keys,
-            },
-        ).unwrap();
+        .request("crypto.sign", ParamsOfSign { unsigned, keys })
+        .unwrap();
 
     assert_eq!(box_sign.signature, keys_sign.signature);
 
@@ -853,16 +870,20 @@ async fn test_signing_box() {
             "crypto.remove_signing_box",
             RegisteredSigningBox {
                 handle: external_box.handle,
-        },
-    ).await.unwrap();
+            },
+        )
+        .await
+        .unwrap();
 
     let _: () = client
         .request_async(
             "crypto.remove_signing_box",
             RegisteredSigningBox {
                 handle: keys_box_handle.into(),
-        },
-    ).await.unwrap();
+            },
+        )
+        .await
+        .unwrap();
 }
 
 #[test]
@@ -882,7 +903,7 @@ fn test_strip_secret() {
 fn test_debug_keypair_secret_stripped() {
     let keypair = KeyPair::new(
         "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".into(),
-        "9123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".into()
+        "9123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".into(),
     );
 
     assert_eq!(
@@ -910,7 +931,7 @@ async fn test_aes_params(key: &str, data: &str, encrypted: &str) {
                     key: key.clone(),
                     iv: Some(iv.clone()),
                     mode: CipherMode::CBC,
-                })
+                }),
             },
         )
         .await
@@ -924,7 +945,9 @@ async fn test_aes_params(key: &str, data: &str, encrypted: &str) {
                 encryption_box: box_handle.clone(),
                 data: base64::encode(&data.clone()),
             },
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
     assert_eq!(result.data, encrypted);
 
@@ -935,20 +958,19 @@ async fn test_aes_params(key: &str, data: &str, encrypted: &str) {
                 encryption_box: box_handle.clone(),
                 data: encrypted,
             },
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
-    assert_eq!(
-        base64::decode(&result.data).unwrap()[..data.len()],
-        data
-    );
+    assert_eq!(base64::decode(&result.data).unwrap()[..data.len()], data);
 
     let _: () = client
         .request_async(
             "crypto.remove_encryption_box",
-            RegisteredEncryptionBox {
-                handle: box_handle,
-        },
-    ).await.unwrap();
+            RegisteredEncryptionBox { handle: box_handle },
+        )
+        .await
+        .unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -956,14 +978,16 @@ async fn test_aes_encryption_box() {
     test_aes_params(
         "src/crypto/test_data/aes128.key.bin",
         "src/crypto/test_data/aes.plaintext.bin",
-        "src/crypto/test_data/cbc-aes128.ciphertext.bin"
-    ).await;
+        "src/crypto/test_data/cbc-aes128.ciphertext.bin",
+    )
+    .await;
 
     test_aes_params(
         "src/crypto/test_data/aes256.key.bin",
         "src/crypto/test_data/aes.plaintext.for.padding.bin",
-        "src/crypto/test_data/cbc-aes256.ciphertext.padded.bin"
-    ).await;
+        "src/crypto/test_data/cbc-aes256.ciphertext.padded.bin",
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -981,8 +1005,8 @@ async fn test_chacha20_encryption_box() {
                     super::boxes::encryption_box::chacha20::ChaCha20ParamsEB {
                         key: key.clone(),
                         nonce: nonce.clone(),
-                    }
-                )
+                    },
+                ),
             },
         )
         .await
@@ -998,7 +1022,9 @@ async fn test_chacha20_encryption_box() {
                 encryption_box: box_handle.clone(),
                 data: decrypted.clone(),
             },
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
     assert_eq!(result.data, "w5QOGsJodQ==");
 
@@ -1009,7 +1035,9 @@ async fn test_chacha20_encryption_box() {
                 encryption_box: box_handle.clone(),
                 data: result.data,
             },
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
     assert_eq!(result.data, decrypted);
 
@@ -1019,7 +1047,9 @@ async fn test_chacha20_encryption_box() {
             ParamsOfEncryptionBoxGetInfo {
                 encryption_box: box_handle,
             },
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
     assert_eq!(
         result.info,
@@ -1046,13 +1076,11 @@ async fn test_nacl_encryption_box() {
         .request_async::<_, RegisteredEncryptionBox>(
             "crypto.create_encryption_box",
             ParamsOfCreateEncryptionBox {
-                algorithm: EncryptionAlgorithm::NaclBox(
-                    NaclBoxParamsEB {
-                        their_public: THEIR_PUBLIC.to_string(),
-                        secret: SECRET.to_string(),
-                        nonce: NONCE.to_string(),
-                    }
-                )
+                algorithm: EncryptionAlgorithm::NaclBox(NaclBoxParamsEB {
+                    their_public: THEIR_PUBLIC.to_string(),
+                    secret: SECRET.to_string(),
+                    nonce: NONCE.to_string(),
+                }),
             },
         )
         .await
@@ -1068,7 +1096,9 @@ async fn test_nacl_encryption_box() {
                 encryption_box: box_handle.clone(),
                 data: decrypted.clone(),
             },
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
     assert_eq!(result.data, "li4XED4kx/pjQ2qdP0eR2d/K30uN94voNADxwA==");
 
@@ -1079,7 +1109,9 @@ async fn test_nacl_encryption_box() {
                 encryption_box: box_handle.clone(),
                 data: result.data,
             },
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
     assert_eq!(result.data, decrypted);
 
@@ -1089,7 +1121,9 @@ async fn test_nacl_encryption_box() {
             ParamsOfEncryptionBoxGetInfo {
                 encryption_box: box_handle,
             },
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
     assert_eq!(
         result.info,
@@ -1116,12 +1150,10 @@ async fn test_nacl_secret_encryption_box() {
         .request_async::<_, RegisteredEncryptionBox>(
             "crypto.create_encryption_box",
             ParamsOfCreateEncryptionBox {
-                algorithm: EncryptionAlgorithm::NaclSecretBox(
-                    NaclSecretBoxParamsEB {
-                        key: KEY.to_string(),
-                        nonce: NONCE.to_string(),
-                    }
-                )
+                algorithm: EncryptionAlgorithm::NaclSecretBox(NaclSecretBoxParamsEB {
+                    key: KEY.to_string(),
+                    nonce: NONCE.to_string(),
+                }),
             },
         )
         .await
@@ -1137,7 +1169,9 @@ async fn test_nacl_secret_encryption_box() {
                 encryption_box: box_handle.clone(),
                 data: decrypted.clone(),
             },
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
     assert_eq!(result.data, "JL7ejKWe2KXmrsns41yfXoQF0t/C1Q8RGyzQ2A==");
 
@@ -1148,7 +1182,9 @@ async fn test_nacl_secret_encryption_box() {
                 encryption_box: box_handle.clone(),
                 data: result.data,
             },
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
     assert_eq!(result.data, decrypted);
 
@@ -1158,7 +1194,9 @@ async fn test_nacl_secret_encryption_box() {
             ParamsOfEncryptionBoxGetInfo {
                 encryption_box: box_handle,
             },
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
     assert_eq!(
         result.info,
@@ -1173,7 +1211,7 @@ async fn test_nacl_secret_encryption_box() {
     );
 }
 
-fn get_callback(
+fn password_provider(
     client: &Arc<TestClient>,
     password_hash: &Arc<String>,
     on_callback: impl Fn() + Send + Sync + 'static,
@@ -1187,14 +1225,15 @@ fn get_callback(
         let on_callback = Arc::clone(&on_callback);
         tokio::spawn(async move {
             on_callback();
-            let ParamsOfAppPasswordProvider::GetPassword { encryption_public_key } =
-                serde_json::from_value(request.request_data).unwrap();
+            let ParamsOfAppPasswordProvider::GetPassword {
+                encryption_public_key,
+            } = serde_json::from_value(request.request_data).unwrap();
 
             let KeyPair { public, secret } =
                 client.request_no_params("crypto.nacl_box_keypair").unwrap();
 
-            let ResultOfNaclBox { encrypted } =
-                client.request_async(
+            let ResultOfNaclBox { encrypted } = client
+                .request_async(
                     "crypto.nacl_box",
                     ParamsOfNaclBox {
                         decrypted: base64::encode(&hex::decode(password_hash.as_ref()).unwrap()),
@@ -1202,16 +1241,19 @@ fn get_callback(
                         their_public: encryption_public_key,
                         secret,
                     },
-                ).await
-                    .unwrap();
+                )
+                .await
+                .unwrap();
 
-            client.resolve_app_request(
-                request.app_request_id,
-                ResultOfAppPasswordProvider::GetPassword {
-                    encrypted_password: encrypted,
-                    app_encryption_pubkey: public,
-                },
-            ).await;
+            client
+                .resolve_app_request(
+                    request.app_request_id,
+                    ResultOfAppPasswordProvider::GetPassword {
+                        encrypted_password: encrypted,
+                        app_encryption_pubkey: public,
+                    },
+                )
+                .await;
         });
         futures::future::ready(())
     }
@@ -1220,9 +1262,8 @@ fn get_callback(
 #[tokio::test]
 async fn test_crypto_boxes() -> ton_types::Result<()> {
     let client = Arc::new(TestClient::new());
-    let password_hash = Arc::new(
-        "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF".to_string()
-    );
+    let password_hash =
+        Arc::new("1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF".to_string());
     let salt = "123123123";
 
     let RegisteredCryptoBox { handle } = client
@@ -1233,15 +1274,18 @@ async fn test_crypto_boxes() -> ton_types::Result<()> {
                 secret: CryptoBoxSecret::RandomSeedPhrase {
                     dictionary: Default::default(),
                     wordcount: 12,
-                }
+                },
             },
-            get_callback(&client, &password_hash, || ()),
-        ).await?;
+            password_provider(&client, &password_hash, || ()),
+        )
+        .await?;
 
-    let seed_phrase: ResultOfGetCryptoBoxSeedPhrase = client.request_async(
-        "crypto.get_crypto_box_seed_phrase",
-        RegisteredCryptoBox { handle },
-    ).await?;
+    let seed_phrase: ResultOfGetCryptoBoxSeedPhrase = client
+        .request_async(
+            "crypto.get_crypto_box_seed_phrase",
+            RegisteredCryptoBox { handle },
+        )
+        .await?;
 
     let verify_result: ResultOfMnemonicVerify = client
         .request(
@@ -1256,10 +1300,9 @@ async fn test_crypto_boxes() -> ton_types::Result<()> {
 
     assert!(verify_result.valid);
 
-    let crypto_box_info: ResultOfGetCryptoBoxInfo = client.request_async(
-        "crypto.get_crypto_box_info",
-        RegisteredCryptoBox { handle },
-    ).await?;
+    let crypto_box_info: ResultOfGetCryptoBoxInfo = client
+        .request_async("crypto.get_crypto_box_info", RegisteredCryptoBox { handle })
+        .await?;
 
     let RegisteredCryptoBox { handle } = client
         .request_async_callback(
@@ -1268,15 +1311,18 @@ async fn test_crypto_boxes() -> ton_types::Result<()> {
                 secret_encryption_salt: salt.to_string(),
                 secret: CryptoBoxSecret::EncryptedSecret {
                     encrypted_secret: crypto_box_info.encrypted_secret.clone(),
-                }
+                },
             },
-            get_callback(&client, &password_hash, || ()),
-        ).await?;
+            password_provider(&client, &password_hash, || ()),
+        )
+        .await?;
 
-    let seed_phrase2: ResultOfGetCryptoBoxSeedPhrase = client.request_async(
-        "crypto.get_crypto_box_seed_phrase",
-        RegisteredCryptoBox { handle },
-    ).await?;
+    let seed_phrase2: ResultOfGetCryptoBoxSeedPhrase = client
+        .request_async(
+            "crypto.get_crypto_box_seed_phrase",
+            RegisteredCryptoBox { handle },
+        )
+        .await?;
 
     assert_eq!(seed_phrase.phrase, seed_phrase2.phrase);
 
@@ -1289,15 +1335,18 @@ async fn test_crypto_boxes() -> ton_types::Result<()> {
                     phrase: seed_phrase.phrase.clone(),
                     dictionary: 0,
                     wordcount: 12,
-                }
+                },
             },
-            get_callback(&client, &password_hash, || ()),
-        ).await?;
+            password_provider(&client, &password_hash, || ()),
+        )
+        .await?;
 
-    let seed_phrase3: ResultOfGetCryptoBoxSeedPhrase = client.request_async(
-        "crypto.get_crypto_box_seed_phrase",
-        RegisteredCryptoBox { handle },
-    ).await?;
+    let seed_phrase3: ResultOfGetCryptoBoxSeedPhrase = client
+        .request_async(
+            "crypto.get_crypto_box_seed_phrase",
+            RegisteredCryptoBox { handle },
+        )
+        .await?;
 
     assert_eq!(seed_phrase.phrase, seed_phrase3.phrase);
 
@@ -1307,99 +1356,114 @@ async fn test_crypto_boxes() -> ton_types::Result<()> {
 #[tokio::test]
 async fn test_crypto_box_signing_boxes() -> ton_types::Result<()> {
     let client = Arc::new(TestClient::new());
-    let password_hash = Arc::new(
-        "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF".to_string()
-    );
+    let password_hash =
+        Arc::new("1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF".to_string());
     let salt = "123123123";
     let callback_calls_counter = Arc::new(AtomicUsize::new(0));
     let callback_calls_counter_copy = Arc::clone(&callback_calls_counter);
 
     assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 0);
 
-    let crypto_box: RegisteredCryptoBox = client.request_async_callback(
-        "crypto.create_crypto_box",
-        ParamsOfCreateCryptoBox {
-            secret_encryption_salt: salt.to_string(),
-            secret: CryptoBoxSecret::RandomSeedPhrase {
-                dictionary: Default::default(),
-                wordcount: 12,
-            }
-        },
-        get_callback(&client, &password_hash, move || {
-            callback_calls_counter_copy.fetch_add(1, Ordering::Relaxed);
-        }),
-    ).await?;
+    let crypto_box: RegisteredCryptoBox = client
+        .request_async_callback(
+            "crypto.create_crypto_box",
+            ParamsOfCreateCryptoBox {
+                secret_encryption_salt: salt.to_string(),
+                secret: CryptoBoxSecret::RandomSeedPhrase {
+                    dictionary: Default::default(),
+                    wordcount: 12,
+                },
+            },
+            password_provider(&client, &password_hash, move || {
+                callback_calls_counter_copy.fetch_add(1, Ordering::Relaxed);
+            }),
+        )
+        .await?;
 
     assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 1);
 
-    let signing_box: RegisteredSigningBox = client.request_async(
-        "crypto.get_signing_box_from_crypto_box",
-        ParamsOfGetSigningBoxFromCryptoBox {
-            handle: crypto_box.handle.0,
-            hdpath: None,
-            secret_lifetime: None,
-        }
-    ).await?;
+    let signing_box: RegisteredSigningBox = client
+        .request_async(
+            "crypto.get_signing_box_from_crypto_box",
+            ParamsOfGetSigningBoxFromCryptoBox {
+                handle: crypto_box.handle.0,
+                hdpath: None,
+                secret_lifetime: None,
+            },
+        )
+        .await?;
 
     assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 1);
 
-    let ResultOfSigningBoxGetPublicKey { pubkey } = client.request_async(
-        "crypto.signing_box_get_public_key",
-        RegisteredSigningBox {
-            handle: signing_box.handle.clone(),
-        }
-    ).await?;
+    let ResultOfSigningBoxGetPublicKey { pubkey } = client
+        .request_async(
+            "crypto.signing_box_get_public_key",
+            RegisteredSigningBox {
+                handle: signing_box.handle.clone(),
+            },
+        )
+        .await?;
 
     assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 2);
     assert_eq!(pubkey.len(), 64);
 
-    let _: ResultOfSigningBoxGetPublicKey = client.request_async(
-        "crypto.signing_box_get_public_key",
-        RegisteredSigningBox {
-            handle: signing_box.handle.clone(),
-        }
-    ).await?;
+    let _: ResultOfSigningBoxGetPublicKey = client
+        .request_async(
+            "crypto.signing_box_get_public_key",
+            RegisteredSigningBox {
+                handle: signing_box.handle.clone(),
+            },
+        )
+        .await?;
 
     assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 3);
 
-    let signing_box: RegisteredSigningBox = client.request_async(
-        "crypto.get_signing_box_from_crypto_box",
-        ParamsOfGetSigningBoxFromCryptoBox {
-            handle: crypto_box.handle.0,
-            hdpath: None,
-            secret_lifetime: Some(u32::MAX),
-        }
-    ).await?;
+    let signing_box: RegisteredSigningBox = client
+        .request_async(
+            "crypto.get_signing_box_from_crypto_box",
+            ParamsOfGetSigningBoxFromCryptoBox {
+                handle: crypto_box.handle.0,
+                hdpath: None,
+                secret_lifetime: Some(u32::MAX),
+            },
+        )
+        .await?;
 
     assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 3);
 
     for _ in 0..3 {
-        let _: ResultOfSigningBoxGetPublicKey = client.request_async(
-            "crypto.signing_box_get_public_key",
-            RegisteredSigningBox {
-                handle: signing_box.handle.clone(),
-            }
-        ).await?;
+        let _: ResultOfSigningBoxGetPublicKey = client
+            .request_async(
+                "crypto.signing_box_get_public_key",
+                RegisteredSigningBox {
+                    handle: signing_box.handle.clone(),
+                },
+            )
+            .await?;
 
         assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 4);
     }
 
-    client.request_async(
-        "crypto.clear_crypto_box_secret_cache",
-        RegisteredCryptoBox {
-            handle: crypto_box.handle.clone(),
-        }
-    ).await?;
+    client
+        .request_async(
+            "crypto.clear_crypto_box_secret_cache",
+            RegisteredCryptoBox {
+                handle: crypto_box.handle.clone(),
+            },
+        )
+        .await?;
 
     assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 4);
 
     for _ in 0..3 {
-        let _: ResultOfSigningBoxGetPublicKey = client.request_async(
-            "crypto.signing_box_get_public_key",
-            RegisteredSigningBox {
-                handle: signing_box.handle.clone(),
-            }
-        ).await?;
+        let _: ResultOfSigningBoxGetPublicKey = client
+            .request_async(
+                "crypto.signing_box_get_public_key",
+                RegisteredSigningBox {
+                    handle: signing_box.handle.clone(),
+                },
+            )
+            .await?;
 
         assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 5);
     }
@@ -1410,9 +1474,8 @@ async fn test_crypto_box_signing_boxes() -> ton_types::Result<()> {
 #[tokio::test]
 async fn test_crypto_box_encryption_boxes() -> ton_types::Result<()> {
     let client = Arc::new(TestClient::new());
-    let password_hash = Arc::new(
-        "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF".to_string()
-    );
+    let password_hash =
+        Arc::new("1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF".to_string());
     let nonce = "ff".repeat(12);
     let salt = "123123123";
     let callback_calls_counter = Arc::new(AtomicUsize::new(0));
@@ -1420,33 +1483,37 @@ async fn test_crypto_box_encryption_boxes() -> ton_types::Result<()> {
 
     assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 0);
 
-    let crypto_box: RegisteredCryptoBox = client.request_async_callback(
-        "crypto.create_crypto_box",
-        ParamsOfCreateCryptoBox {
-            secret_encryption_salt: salt.to_string(),
-            secret: CryptoBoxSecret::RandomSeedPhrase {
-                dictionary: Default::default(),
-                wordcount: 12,
-            }
-        },
-        get_callback(&client, &password_hash, move || {
-            callback_calls_counter_copy.fetch_add(1, Ordering::Relaxed);
-        }),
-    ).await?;
+    let crypto_box: RegisteredCryptoBox = client
+        .request_async_callback(
+            "crypto.create_crypto_box",
+            ParamsOfCreateCryptoBox {
+                secret_encryption_salt: salt.to_string(),
+                secret: CryptoBoxSecret::RandomSeedPhrase {
+                    dictionary: Default::default(),
+                    wordcount: 12,
+                },
+            },
+            password_provider(&client, &password_hash, move || {
+                callback_calls_counter_copy.fetch_add(1, Ordering::Relaxed);
+            }),
+        )
+        .await?;
 
     assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 1);
 
-    let encryption_box: RegisteredEncryptionBox = client.request_async(
-        "crypto.get_encryption_box_from_crypto_box",
-        ParamsOfGetEncryptionBoxFromCryptoBox {
-            handle: crypto_box.handle.0,
-            hdpath: None,
-            algorithm: BoxEncryptionAlgorithm::ChaCha20(ChaCha20ParamsCB {
-                nonce: nonce.clone(),
-            }),
-            secret_lifetime: None,
-        }
-    ).await?;
+    let encryption_box: RegisteredEncryptionBox = client
+        .request_async(
+            "crypto.get_encryption_box_from_crypto_box",
+            ParamsOfGetEncryptionBoxFromCryptoBox {
+                handle: crypto_box.handle.0,
+                hdpath: None,
+                algorithm: BoxEncryptionAlgorithm::ChaCha20(ChaCha20ParamsCB {
+                    nonce: nonce.clone(),
+                }),
+                secret_lifetime: None,
+            },
+        )
+        .await?;
 
     assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 1);
 
@@ -1456,7 +1523,8 @@ async fn test_crypto_box_encryption_boxes() -> ton_types::Result<()> {
             ParamsOfEncryptionBoxGetInfo {
                 encryption_box: encryption_box.handle.clone(),
             },
-        ).await?;
+        )
+        .await?;
 
     assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 2);
 
@@ -1478,21 +1546,24 @@ async fn test_crypto_box_encryption_boxes() -> ton_types::Result<()> {
             ParamsOfEncryptionBoxGetInfo {
                 encryption_box: encryption_box.handle.clone(),
             },
-        ).await?;
+        )
+        .await?;
 
     assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 3);
 
-    let encryption_box: RegisteredEncryptionBox = client.request_async(
-        "crypto.get_encryption_box_from_crypto_box",
-        ParamsOfGetEncryptionBoxFromCryptoBox {
-            handle: crypto_box.handle.0,
-            hdpath: None,
-            algorithm: BoxEncryptionAlgorithm::ChaCha20(ChaCha20ParamsCB {
-                nonce: nonce.clone(),
-            }),
-            secret_lifetime: Some(u32::MAX),
-        }
-    ).await?;
+    let encryption_box: RegisteredEncryptionBox = client
+        .request_async(
+            "crypto.get_encryption_box_from_crypto_box",
+            ParamsOfGetEncryptionBoxFromCryptoBox {
+                handle: crypto_box.handle.0,
+                hdpath: None,
+                algorithm: BoxEncryptionAlgorithm::ChaCha20(ChaCha20ParamsCB {
+                    nonce: nonce.clone(),
+                }),
+                secret_lifetime: Some(u32::MAX),
+            },
+        )
+        .await?;
 
     assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 3);
 
@@ -1503,17 +1574,20 @@ async fn test_crypto_box_encryption_boxes() -> ton_types::Result<()> {
                 ParamsOfEncryptionBoxGetInfo {
                     encryption_box: encryption_box.handle.clone(),
                 },
-            ).await?;
+            )
+            .await?;
 
         assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 4);
     }
 
-    client.request_async(
-        "crypto.clear_crypto_box_secret_cache",
-        RegisteredCryptoBox {
-            handle: crypto_box.handle.clone(),
-        }
-    ).await?;
+    client
+        .request_async(
+            "crypto.clear_crypto_box_secret_cache",
+            RegisteredCryptoBox {
+                handle: crypto_box.handle.clone(),
+            },
+        )
+        .await?;
 
     assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 4);
 
@@ -1524,10 +1598,60 @@ async fn test_crypto_box_encryption_boxes() -> ton_types::Result<()> {
                 ParamsOfEncryptionBoxGetInfo {
                     encryption_box: encryption_box.handle.clone(),
                 },
-            ).await?;
+            )
+            .await?;
 
         assert_eq!(callback_calls_counter.load(Ordering::Relaxed), 5);
     }
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_crypto_box_derive_key_cache() -> ton_types::Result<()> {
+    let client = Arc::new(TestClient::new());
+    let password_hash =
+        Arc::new("1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF".to_string());
+    let salt = "123123123";
+    let phrase = "abandon math mimic master filter design carbon crystal rookie group knife young";
+
+    let start1 = client.context().env.now_ms();
+    for _ in 0..5 {
+        let _: RegisteredCryptoBox = client
+            .request_async_callback(
+                "crypto.create_crypto_box",
+                ParamsOfCreateCryptoBox {
+                    secret_encryption_salt: salt.to_string(),
+                    secret: CryptoBoxSecret::PredefinedSeedPhrase {
+                        dictionary: 1,
+                        wordcount: 12,
+                        phrase: phrase.into(),
+                    },
+                },
+                password_provider(&client, &password_hash, || ()),
+            )
+            .await?;
+    }
+    let time1 = client.context().env.now_ms() - start1;
+
+    let start2 = client.context().env.now_ms();
+    for i in 0..5 {
+        let _: RegisteredCryptoBox = client
+            .request_async_callback(
+                "crypto.create_crypto_box",
+                ParamsOfCreateCryptoBox {
+                    secret_encryption_salt: format!("{}{}", salt, i),
+                    secret: CryptoBoxSecret::PredefinedSeedPhrase {
+                        dictionary: 1,
+                        wordcount: 12,
+                        phrase: phrase.into(),
+                    },
+                },
+                password_provider(&client, &password_hash, || ()),
+            )
+            .await?;
+    }
+    let time2 = client.context().env.now_ms() - start2;
+    assert!(time1 * 3 < time2);
     Ok(())
 }

--- a/tools/api.json
+++ b/tools/api.json
@@ -1310,29 +1310,61 @@
           "enum_types": [
             {
               "name": "AES",
-              "type": "Ref",
-              "ref_name": "crypto.AesParamsEB",
+              "type": "Struct",
+              "struct_fields": [
+                {
+                  "name": "value",
+                  "type": "Ref",
+                  "ref_name": "crypto.AesParamsEB",
+                  "summary": null,
+                  "description": null
+                }
+              ],
               "summary": null,
               "description": null
             },
             {
               "name": "ChaCha20",
-              "type": "Ref",
-              "ref_name": "crypto.ChaCha20ParamsEB",
+              "type": "Struct",
+              "struct_fields": [
+                {
+                  "name": "value",
+                  "type": "Ref",
+                  "ref_name": "crypto.ChaCha20ParamsEB",
+                  "summary": null,
+                  "description": null
+                }
+              ],
               "summary": null,
               "description": null
             },
             {
               "name": "NaclBox",
-              "type": "Ref",
-              "ref_name": "crypto.NaclBoxParamsEB",
+              "type": "Struct",
+              "struct_fields": [
+                {
+                  "name": "value",
+                  "type": "Ref",
+                  "ref_name": "crypto.NaclBoxParamsEB",
+                  "summary": null,
+                  "description": null
+                }
+              ],
               "summary": null,
               "description": null
             },
             {
               "name": "NaclSecretBox",
-              "type": "Ref",
-              "ref_name": "crypto.NaclSecretBoxParamsEB",
+              "type": "Struct",
+              "struct_fields": [
+                {
+                  "name": "value",
+                  "type": "Ref",
+                  "ref_name": "crypto.NaclSecretBoxParamsEB",
+                  "summary": null,
+                  "description": null
+                }
+              ],
               "summary": null,
               "description": null
             }
@@ -1588,22 +1620,46 @@
           "enum_types": [
             {
               "name": "ChaCha20",
-              "type": "Ref",
-              "ref_name": "crypto.ChaCha20ParamsCB",
+              "type": "Struct",
+              "struct_fields": [
+                {
+                  "name": "value",
+                  "type": "Ref",
+                  "ref_name": "crypto.ChaCha20ParamsCB",
+                  "summary": null,
+                  "description": null
+                }
+              ],
               "summary": null,
               "description": null
             },
             {
               "name": "NaclBox",
-              "type": "Ref",
-              "ref_name": "crypto.NaclBoxParamsCB",
+              "type": "Struct",
+              "struct_fields": [
+                {
+                  "name": "value",
+                  "type": "Ref",
+                  "ref_name": "crypto.NaclBoxParamsCB",
+                  "summary": null,
+                  "description": null
+                }
+              ],
               "summary": null,
               "description": null
             },
             {
               "name": "NaclSecretBox",
-              "type": "Ref",
-              "ref_name": "crypto.NaclSecretBoxParamsCB",
+              "type": "Struct",
+              "struct_fields": [
+                {
+                  "name": "value",
+                  "type": "Ref",
+                  "ref_name": "crypto.NaclSecretBoxParamsCB",
+                  "summary": null,
+                  "description": null
+                }
+              ],
               "summary": null,
               "description": null
             }


### PR DESCRIPTION
  When user creates crypto box, SDK encrypts provided secret information using provided password
  and salt.
  When SDK encrypts secret, it derives encryption key from password and salt using `scrypt`
  function which takes a lot of CPU time (about 1 second).
  So when the user creates many crypto boxes using same password and salt, it is required a lot
  of time (about 12 seconds for 10 crypto boxes).
  With optimisations introduced in this version the SDK caches mapping (password+salt => encryption key)
  for approximately 2 seconds.
  So when the user creates many crypto boxes using same password and salt, it is required only
  a 1.2 seconds for 10 crypto boxes.